### PR TITLE
Use pathlib for file path management

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ lines_after_imports=2
 lines_between_types=1
 use_parentheses=true
 known_first_party="interrogate"
-known_third_party=["attr", "click", "py", "pytest", "setuptools", "tabulate"]
+known_third_party=["attrs", "click", "py", "pytest", "setuptools", "tabulate"]
 
 [tool.interrogate]
 ignore-init-method = true

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ CLASSIFIERS = [
     "Topic :: Software Development :: Quality Assurance",
 ]
 INSTALL_REQUIRES = [
-    "attrs",
+    "attrs>=19.2",
     "click",
     "py",
     "tabulate",

--- a/src/interrogate/cli.py
+++ b/src/interrogate/cli.py
@@ -4,6 +4,8 @@
 import os
 import sys
 
+from pathlib import Path
+
 import click
 
 from interrogate import __version__ as version
@@ -200,7 +202,9 @@ def main(paths, **kwargs):
     .. versionadded:: 1.1.3 ``--whitelist-regex``
     """
     if not paths:
-        paths = (os.path.abspath(os.getcwd()),)
+        paths = (Path.cwd(),)
+    else:
+        paths = tuple(Path(p) for p in paths)
 
     # NOTE: this will need to be fixed if we want to start supporting
     #       --whitelist-regex on filenames. This otherwise assumes you

--- a/src/interrogate/utils.py
+++ b/src/interrogate/utils.py
@@ -3,9 +3,12 @@
 
 import contextlib
 import itertools
+import os
 import re
 import shutil
 import sys
+
+from pathlib import Path
 
 import tabulate
 
@@ -65,13 +68,8 @@ def get_common_base(files):
     :rtype: str
     """
 
-    def allnamesequal(name):
-        """Return if all names in an iterable are equal."""
-        return all(n == name[0] for n in name[1:])
 
-    level_slices = zip(*[f.split("/") for f in files])
-    tw = itertools.takewhile(allnamesequal, level_slices)
-    return "/".join(x[0] for x in tw)
+    return Path(os.path.commonpath(files))
 
 
 def interrogate_line_formatter(padded_cells, colwidths, colaligns):

--- a/src/interrogate/utils.py
+++ b/src/interrogate/utils.py
@@ -65,11 +65,16 @@ def get_common_base(files):
     :param files: files to scan.
     :type files: ``iterable``
     :return: Common parent path.
-    :rtype: str
+    :rtype: Path
     """
 
 
-    return Path(os.path.commonpath(files))
+    # Maintain Python 3.5 compatibility
+    try:
+        common_base =Path(os.path.commonpath(files))
+    except TypeError:
+        common_base = Path(os.path.commonpath([str(f) for f in files]))
+    return common_base
 
 
 def interrogate_line_formatter(padded_cells, colwidths, colaligns):

--- a/tests/functional/test_coverage.py
+++ b/tests/functional/test_coverage.py
@@ -3,28 +3,30 @@
 
 import os
 
+from pathlib import Path
+
 import pytest
 
 from interrogate import config
 from interrogate import coverage
 
 
-HERE = os.path.abspath(os.path.join(os.path.abspath(__file__), os.path.pardir))
-SAMPLE_DIR = os.path.join(HERE, "sample")
-FIXTURES = os.path.join(HERE, "fixtures")
+HERE = Path(__file__).parent
+SAMPLE_DIR = HERE / "sample"
+FIXTURES = HERE / "fixtures"
 
 
 @pytest.mark.parametrize(
     "paths,conf,exp_results",
     (
-        ([os.path.join(SAMPLE_DIR, "empty.py"),], {}, (1, 0, 1, "0.0")),
+        ([SAMPLE_DIR / "empty.py",], {}, (1, 0, 1, "0.0")),
         (
-            [os.path.join(SAMPLE_DIR, "empty.py"),],
+            [SAMPLE_DIR / "empty.py",],
             {"ignore_module": True},
             (0, 0, 0, "0.0"),
         ),
         ([SAMPLE_DIR,], {}, (52, 24, 28, "46.2")),
-        ([os.path.join(SAMPLE_DIR, "partial.py")], {}, (20, 7, 13, "35.0")),
+        ([SAMPLE_DIR / "partial.py"], {}, (20, 7, 13, "35.0")),
     ),
 )
 def test_coverage_simple(paths, conf, exp_results, mocker):
@@ -42,7 +44,7 @@ def test_coverage_simple(paths, conf, exp_results, mocker):
 
 def test_coverage_errors(capsys):
     """Exit when no Python files are found."""
-    path = os.path.join(SAMPLE_DIR, "ignoreme.txt")
+    path = SAMPLE_DIR / "ignoreme.txt"
     interrogate_coverage = coverage.InterrogateCoverage(paths=[path])
 
     with pytest.raises(SystemExit, match="1"):
@@ -79,7 +81,7 @@ def test_print_results(level, exp_fixture_file, capsys, monkeypatch):
     )
 
     captured = capsys.readouterr()
-    expected_fixture = os.path.join(FIXTURES, exp_fixture_file)
+    expected_fixture = FIXTURES / exp_fixture_file
     with open(expected_fixture, "r") as f:
         expected_out = f.read()
     assert expected_out in captured.out
@@ -112,7 +114,7 @@ def test_print_results_ignore_module(
     )
 
     captured = capsys.readouterr()
-    expected_fixture = os.path.join(FIXTURES, exp_fixture_file)
+    expected_fixture = FIXTURES / exp_fixture_file
     with open(expected_fixture, "r") as f:
         expected_out = f.read()
     assert expected_out in captured.out
@@ -122,7 +124,7 @@ def test_print_results_single_file(capsys, monkeypatch):
     """Results for a single file should still list the filename."""
 
     monkeypatch.setattr(coverage.utils, "TERMINAL_WIDTH", 80)
-    single_file = os.path.join(SAMPLE_DIR, "full.py")
+    single_file = SAMPLE_DIR / "full.py"
     interrogate_coverage = coverage.InterrogateCoverage(paths=[single_file])
     results = interrogate_coverage.get_coverage()
     interrogate_coverage.print_results(
@@ -130,9 +132,7 @@ def test_print_results_single_file(capsys, monkeypatch):
     )
 
     captured = capsys.readouterr()
-    expected_fixture = os.path.join(
-        FIXTURES, "expected_detailed_single_file.txt"
-    )
+    expected_fixture = FIXTURES / "expected_detailed_single_file.txt"
     with open(expected_fixture, "r") as f:
         expected_out = f.read()
     assert expected_out in captured.out

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -4,6 +4,8 @@
 import re
 import sys
 
+from pathlib import Path
+
 import pytest
 
 from interrogate import utils
@@ -50,9 +52,9 @@ def test_smart_open(filename, mocker):
 @pytest.mark.parametrize(
     "files,expected",
     (
-        (("/usr/src/app", "/usr/src/tests"), "/usr/src"),
-        (("/usr/src/app/sample.py", "/usr/src/tests"), "/usr/src"),
-        (("/usr/src/app", "/src/tests"), ""),
+        ((Path("/usr/src/app"), Path("/usr/src/tests")), Path("/usr/src")),
+        ((Path("/usr/src/app/sample.py"), Path("/usr/src/tests")), Path("/usr/src")),
+        ((Path("/usr/src/app"), Path("/src/tests")), Path("/")),
     ),
 )
 def test_get_common_base(files, expected):


### PR DESCRIPTION
This PR uses `pathlib` for file path management, which should make cross-platform support easier.

This PR resolves #15 

`pathlib` could be implemented to replace a lot of `os` usage elsewhere in the project, but this PR was focused on `coverage.py`.

**ATTN:** @econchick 

The original tests don't run properly on Windows, but this was tested and run on Linux, where all tests passed.

The default `common_base = ""` is now `common_base = Path("/")`. I'm not sure if this is fine with you, or if this breaks something in your use case.

Tests were updated, but hopefully they still test the properties you intended.

Let me know if there is anything that is not quite right, or some lines that could use some explanation. There are still some cases where a `Path` was converted into a `str` or where `os` was used. There may be a more elegant solution that I'm not familiar with.