### PR TITLE
Include link to Github Action in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -393,6 +393,11 @@ To view all options available, run ``interrogate --help``:
 
       -h, --help                     Show this message and exit.
 
+Interrogate with Github Actions
+===============================
+
+``interrogate`` can be integrated into your project CI/CD with GitHub Actions! Check out the Action by `Jack McKew
+<https://github.com/JackMcKew>`_ over at https://github.com/marketplace/actions/python-interrogate-check.
 
 .. start-credits
 


### PR DESCRIPTION
Hey!

Absolutely love this package, thank you so much! I wanted to use this in my CI/CD pipeline for https://github.com/JackMcKew/pandas_alive so I created a Github Action that can either fail your CI/CD with a limit and/or generate the badge.

Just adding a link to this in the README so others can use this as well 👍 