### PR TITLE
allow for non-existant paths in -e

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -16,6 +16,7 @@ Fixed
 ^^^^^
 
 * Output now alpha-sorts by directory.
+* ``-e`` / ``--exclude`` doesn't error if a non-existent file/directory is passed (`#38 <https://github.com/econchick/interrogate/issues/38>`_).
 
 .. short-log
 

--- a/src/interrogate/cli.py
+++ b/src/interrogate/cli.py
@@ -47,7 +47,6 @@ from interrogate import utils
     "--exclude",
     multiple=True,
     type=click.Path(
-        exists=True,
         file_okay=True,
         dir_okay=True,
         writable=False,

--- a/tests/functional/test_cli.py
+++ b/tests/functional/test_cli.py
@@ -56,6 +56,8 @@ def test_run_no_paths(runner, monkeypatch, tmpdir):
         (["-w", "^get$"], 50.0, 1),
         # exclude file
         (["-e", os.path.join(SAMPLE_DIR, "partial.py")], 53.1, 1),
+        # exclude file which doesn't exist
+        (["-e", os.path.join(SAMPLE_DIR, "does.not.exist")], 46.2, 1),
         # fail under
         (["-f", "40"], 46.2, 0),
     ),


### PR DESCRIPTION
# Hey, I just made a Pull Request!

## Description
`-e` / `--exclude` doesn't error if the file/directory passed doesn't exist

## Motivation and Context
closes #38 

## Have you tested this? If so, how?
test added

## Checklist for PR author(s)
<!-- If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing left to do. -->
- [ ] Changes are covered by unit tests (no major decrease in code coverage %).
- [ ] All tests pass.
- [ ] Docstring coverage is **100%** via `tox -e docs` or `interrogate -c pyproject.toml` (I mean, we _should_ set a good example :smile:).
- [ ] Updates to documentation:
    - [ ] Document any relevant additions/changes in `README.rst`.
    - [ ] Manually update **both** the `README.rst` _and_ `docs/index.rst` for any new/changed CLI flags.
    - [ ] Any changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/markup/para.html#directive-versionadded).  Find the appropriate next version in the project's [``__init__.py``](https://github.com/econchick/interrogate/blob/master/src/interrogate/__init__.py) file.

## Release note
<!--  If your change is non-trivial (e.g. more than a fixed typo in docs, or updated tests), please write a suggested release note for us to include in `docs/changelog.rst` (we may edit it a bit).

1. Enter your release note in the below block. If the PR requires additional action from users switching to the new release, start the release note with the string "action required: ". Please write it in the imperative.
2. If no release note is required, just write "NONE".
-->
```release-note

```

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
