### PR TITLE
Automatically detect pyproject.toml

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -297,7 +297,7 @@ Use it within your code directly:
     InterrogateResults(total=68, covered=65, missing=3)
 
 
-Configure within your ``pyproject.toml``:
+Configure within your ``pyproject.toml`` (``interrogate`` will automatically detect a ``pyproject.toml`` file and pick up default values for the command line options):
 
 .. code-block:: console
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+1.3.0 (UNRELEASED)
+
+Added
+^^^^^
+
+* Read configuration from ``pyproject.toml`` by default (`#36 <https://github.com/econchick/interrogate/issues/36>`_).
+
 .. short-log
 
 1.2.0 (2020-05-19)

--- a/src/interrogate/cli.py
+++ b/src/interrogate/cli.py
@@ -160,16 +160,6 @@ from interrogate import utils
     help="Write output to a given FILE.  [default: stdout]",
 )
 @click.option(
-    "-c",
-    "--config",
-    type=click.Path(
-        exists=False, file_okay=True, dir_okay=False, readable=True
-    ),
-    is_eager=True,
-    callback=config.read_pyproject_toml,
-    help="Read configuration from `pyproject.toml`.",
-)
-@click.option(
     "--color/--no-color",
     is_flag=True,
     default=True,
@@ -204,9 +194,21 @@ from interrogate import utils
         readable=True,
         resolve_path=True,
     ),
+    is_eager=True,
     nargs=-1,
 )
-def main(paths, **kwargs):
+@click.option(
+    "-c",
+    "--config",
+    type=click.Path(
+        exists=False, file_okay=True, dir_okay=False, readable=True
+    ),
+    is_eager=True,
+    callback=config.read_pyproject_toml,
+    help="Read configuration from `pyproject.toml`.",
+)
+@click.pass_context
+def main(ctx, paths, **kwargs):
     """Measure and report on documentation coverage in Python modules.
 
     \f

--- a/src/interrogate/config.py
+++ b/src/interrogate/config.py
@@ -4,6 +4,7 @@ Configuration-related helpers.
 """
 # Adapted from Black https://github.com/psf/black/blob/master/black.py.
 
+import os
 import pathlib
 
 import attr
@@ -114,9 +115,11 @@ def read_pyproject_toml(ctx, param, value):
     :raise click.FileError: if ``pyproject.toml`` is not parseable or
         otherwise not available (i.e. does not exist).
     """
-    assert not isinstance(value, (int, bool)), "Invalid parameter type passed"
     if not value:
-        value = find_pyproject_toml(ctx.params.get("paths", ()))
+        paths = ctx.params.get("paths")
+        if not paths:
+            paths = (os.path.abspath(os.getcwd()),)
+        value = find_pyproject_toml(paths)
         if value is None:
             return None
 

--- a/tests/functional/test_cli.py
+++ b/tests/functional/test_cli.py
@@ -9,6 +9,7 @@ import pytest
 from click import testing
 
 from interrogate import cli
+from interrogate import config
 
 
 HERE = os.path.abspath(os.path.join(os.path.abspath(__file__), os.path.pardir))
@@ -18,8 +19,11 @@ IS_WINDOWS = sys.platform in ("cygwin", "win32")
 
 
 @pytest.fixture
-def runner():
+def runner(monkeypatch):
     """Click fixture runner"""
+    # don't let the tests accidentally bring in the project's own
+    # pyproject.toml
+    monkeypatch.setattr(config, "find_pyproject_toml", lambda x: None)
     return testing.CliRunner()
 
 

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -122,12 +122,6 @@ def test_read_pyproject_toml(
 
 def test_read_pyproject_toml_raises(mocker, monkeypatch):
     """Handle expected exceptions while reading pyproject.toml, if any."""
-    with pytest.raises(AssertionError, match="Invalid parameter type passed"):
-        config.read_pyproject_toml({}, "foo", True)
-
-    with pytest.raises(AssertionError, match="Invalid parameter type passed"):
-        config.read_pyproject_toml({}, "foo", 123)
-
     toml_error = toml.TomlDecodeError("toml error", doc="foo", pos=0)
     os_error = OSError("os error")
     mock_parse_pyproject_toml = mocker.Mock()

--- a/tox.ini
+++ b/tox.ini
@@ -57,7 +57,6 @@ ignore = E203, E231, W503
 
 [pytest]
 addopts = -v --cov=interrogate --cov-report=xml:coverage.xml --cov-report=term-missing
-strict = true
 testpaths = tests
 
 


### PR DESCRIPTION
# Hey, I just made a Pull Request!

## Description
<!--- Describe your changes -->

This addresses #36 - if a `pyproject.toml` exists for the project, `interrogate` will automatically pick up configured values and set them as the CLI options' defaults.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." and -->
<!--- "I ran `interrogate` with these changes over some code and it works for me." -->

## Checklist for PR author(s)
<!-- If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing left to do. -->
- [x] Changes are covered by unit tests (no major decrease in code coverage %).
- [x] All tests pass.
- [x] Docstring coverage is **100%** via `tox -e docs` or `interrogate -c pyproject.toml` (I mean, we _should_ set a good example :smile:).
- [x] Updates to documentation:
    - [x] Document any relevant additions/changes in `README.rst`.
    - [x] Manually update **both** the `README.rst` _and_ `docs/index.rst` for any new/changed CLI flags.
    - [x] Any changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/markup/para.html#directive-versionadded).  Find the appropriate next version in the project's [``__init__.py``](https://github.com/econchick/interrogate/blob/master/src/interrogate/__init__.py) file.

## Release note
<!--  If your change is non-trivial (e.g. more than a fixed typo in docs, or updated tests), please write a suggested release note for us to include in `docs/changelog.rst` (we may edit it a bit).

1. Enter your release note in the below block. If the PR requires additional action from users switching to the new release, start the release note with the string "action required: ". Please write it in the imperative.
2. If no release note is required, just write "NONE".
-->
```release-note
Read configuration from ``pyproject.toml`` by default 
```

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
