### PR TITLE
Parse configuration from setup.cfg

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -82,7 +82,7 @@ Add verbosity to see a summary:
     | src/interrogate/__main__.py           |       1 |      0 |       1 |     100% |
     | src/interrogate/badge_gen.py          |       5 |      0 |       5 |     100% |
     | src/interrogate/cli.py                |       2 |      0 |       2 |     100% |
-    | src/interrogate/config.py             |       6 |      0 |       6 |     100% |
+    | src/interrogate/config.py             |       8 |      0 |       8 |     100% |
     | src/interrogate/coverage.py           |      25 |      0 |      25 |     100% |
     | src/interrogate/utils.py              |      10 |      0 |      10 |     100% |
     | src/interrogate/visit.py              |      16 |      0 |      16 |     100% |
@@ -91,11 +91,11 @@ Add verbosity to see a summary:
     | tests/functional/test_coverage.py     |       6 |      0 |       6 |     100% |
     | tests/unit/__init__.py                |       1 |      0 |       1 |     100% |
     | tests/unit/test_badge_gen.py          |       6 |      0 |       6 |     100% |
-    | tests/unit/test_config.py             |       7 |      0 |       7 |     100% |
+    | tests/unit/test_config.py             |      10 |      0 |      10 |     100% |
     | tests/unit/test_utils.py              |      13 |      0 |      13 |     100% |
     |---------------------------------------|---------|--------|---------|----------|
-    | TOTAL                                 |     107 |      0 |     107 |   100.0% |
-    ---------------- RESULT: PASSED (minimum: 80.0%, actual: 100.0%) ----------------
+    | TOTAL                                 |     112 |      0 |     112 |   100.0% |
+    ---------------- RESULT: PASSED (minimum: 95.0%, actual: 100.0%) ----------------
 
 
 Add even *more* verbosity:
@@ -123,11 +123,13 @@ Add even *more* verbosity:
     |   main (L218)                                                       | COVERED |
     |---------------------------------------------------------------------|---------|
     | src/interrogate/config.py (module)                                  | COVERED |
-    |   InterrogateConfig (L16)                                           | COVERED |
-    |   find_project_root (L51)                                           | COVERED |
-    |   find_pyproject_toml (L79)                                         | COVERED |
-    |   parse_pyproject_toml (L86)                                        | COVERED |
-    |   read_pyproject_toml (L102)                                        | COVERED |
+    |   InterrogateConfig (L17)                                           | COVERED |
+    |   find_project_root (L52)                                           | COVERED |
+    |   find_project_config (L80)                                         | COVERED |
+    |   parse_pyproject_toml (L91)                                        | COVERED |
+    |   sanitize_list_values (L107)                                       | COVERED |
+    |   parse_setup_cfg (L130)                                            | COVERED |
+    |   read_config_file (L164)                                           | COVERED |
     |---------------------------------------------------------------------|---------|
     | src/interrogate/coverage.py (module)                                | COVERED |
     |   BaseInterrogateResult (L21)                                       | COVERED |
@@ -210,12 +212,15 @@ Add even *more* verbosity:
     |   test_create (L102)                                                | COVERED |
     |---------------------------------------------------------------------|---------|
     | tests/unit/test_config.py (module)                                  | COVERED |
-    |   test_find_project_root (L28)                                      | COVERED |
-    |   test_find_pyproject_toml (L44)                                    | COVERED |
-    |   test_parse_pyproject_toml (L53)                                   | COVERED |
-    |   test_read_pyproject_toml_none (L69)                               | COVERED |
-    |   test_read_pyproject_toml (L108)                                   | COVERED |
-    |   test_read_pyproject_toml_raises (L123)                            | COVERED |
+    |   test_find_project_root (L29)                                      | COVERED |
+    |   test_find_project_config (L45)                                    | COVERED |
+    |   test_parse_pyproject_toml (L54)                                   | COVERED |
+    |   test_sanitize_list_values (L84)                                   | COVERED |
+    |   test_parse_setup_cfg (L89)                                        | COVERED |
+    |   test_parse_setup_cfg_raises (L114)                                | COVERED |
+    |   test_read_config_file_none (L125)                                 | COVERED |
+    |   test_read_config_file (L184)                                      | COVERED |
+    |   test_read_config_file_raises (L198)                               | COVERED |
     |---------------------------------------------------------------------|---------|
     | tests/unit/test_utils.py (module)                                   | COVERED |
     |   test_parse_regex (L32)                                            | COVERED |
@@ -239,7 +244,7 @@ Add even *more* verbosity:
     | src/interrogate/__main__.py           |       1 |      0 |       1 |     100% |
     | src/interrogate/badge_gen.py          |       5 |      0 |       5 |     100% |
     | src/interrogate/cli.py                |       2 |      0 |       2 |     100% |
-    | src/interrogate/config.py             |       6 |      0 |       6 |     100% |
+    | src/interrogate/config.py             |       8 |      0 |       8 |     100% |
     | src/interrogate/coverage.py           |      25 |      0 |      25 |     100% |
     | src/interrogate/utils.py              |      10 |      0 |      10 |     100% |
     | src/interrogate/visit.py              |      16 |      0 |      16 |     100% |
@@ -248,12 +253,11 @@ Add even *more* verbosity:
     | tests/functional/test_coverage.py     |       6 |      0 |       6 |     100% |
     | tests/unit/__init__.py                |       1 |      0 |       1 |     100% |
     | tests/unit/test_badge_gen.py          |       6 |      0 |       6 |     100% |
-    | tests/unit/test_config.py             |       7 |      0 |       7 |     100% |
+    | tests/unit/test_config.py             |      10 |      0 |      10 |     100% |
     | tests/unit/test_utils.py              |      13 |      0 |      13 |     100% |
     |---------------------------------------|---------|--------|---------|----------|
-    | TOTAL                                 |     107 |      0 |     107 |   100.0% |
-    ---------------- RESULT: PASSED (minimum: 80.0%, actual: 100.0%) ----------------
-
+    | TOTAL                                 |     112 |      0 |     112 |   100.0% |
+    ---------------- RESULT: PASSED (minimum: 95.0%, actual: 100.0%) ----------------
 
 Other Usage
 ===========
@@ -298,6 +302,12 @@ Use it within your code directly:
     InterrogateResults(total=68, covered=65, missing=3)
 
 
+Use ``interrogate`` with `GitHub Actions <https://github.com/features/actions>`_. Check out the `action <https://github.com/marketplace/actions/python-interrogate-check>`_ written & maintained by `Jack McKew <https://github.com/JackMcKew>`_ (thank you, Jack!).
+
+
+Configuration
+=============
+
 Configure within your ``pyproject.toml`` (``interrogate`` will automatically detect a ``pyproject.toml`` file and pick up default values for the command line options):
 
 .. code-block:: console
@@ -323,8 +333,34 @@ Configure within your ``pyproject.toml`` (``interrogate`` will automatically det
     color = true
 
 
+Or configure within your ``setup.cfg`` (``interrogate`` will automatically detect a ``setup.cfg`` file and pick up default values for the command line options):
 
-Use ``interrogate`` with `GitHub Actions <https://github.com/features/actions>`_! Check out the `action <https://github.com/marketplace/actions/python-interrogate-check>`_ written & maintained by `Jack McKew <https://github.com/JackMcKew>`_ (thank you, Jack!).
+.. code-block:: console
+
+    $ interrogate -c setup.cfg [OPTIONS] [PATHS]...
+
+.. code-block:: ini
+
+    [tool:interrogate]
+    ignore-init-method = true
+    ignore-init-module = false
+    ignore-magic = false
+    ignore-semiprivate = false
+    ignore-private = false
+    ignore-property-decorators = false
+    ignore-module = false
+    fail-under = 95
+    exclude = setup.py,docs,build
+    ignore-regex = ^get$,^mock_.*,.*BaseClass.*
+    verbose = 0
+    quiet = false
+    whitelist-regex =
+    color = true
+
+
+.. warning::
+
+    The use of ``setup.cfg`` is not recommended unless for very simple use cases. ``.cfg`` files use a different parser than ``pyproject.toml`` which might cause hard to track down problems. When possible, it is recommended to use ``pyproject.toml`` to define your interrogate configuration.
 
 
 .. end-readme
@@ -403,7 +439,8 @@ To view all options available, run ``interrogate --help``:
                                       image) in at a given file or directory.
 
       -h, --help                      Show this message and exit.
-      -c, --config FILE               Read configuration from `pyproject.toml`.
+      -c, --config FILE               Read configuration from `pyproject.toml` or
+                                      `setup.cfg`.
 
 .. start-credits
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -8,6 +8,7 @@ Added
 
 * Read configuration from ``pyproject.toml`` by default (`#36 <https://github.com/econchick/interrogate/issues/36>`_).
 * Add ``-P`` / ``--ignore-property-decorators`` flag to ignore methods with property getter/setter decorators (`#37 <https://github.com/econchick/interrogate/issues/37>`_).
+* Add support for read configuration from ``setup.cfg`` (`#35 <https://github.com/econchick/interrogate/issues/35>`_).
 
 Fixed
 ^^^^^

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -88,7 +88,7 @@ Command Line Options
 
 .. option:: -c, --config FILE
 
-    Read configuration from ``pyproject.toml``.
+    Read configuration from ``pyproject.toml`` or ``setup.cfg``.
 
 .. option:: --color, --no-color
 

--- a/src/interrogate/cli.py
+++ b/src/interrogate/cli.py
@@ -211,8 +211,8 @@ from interrogate import utils
         exists=False, file_okay=True, dir_okay=False, readable=True
     ),
     is_eager=True,
-    callback=config.read_pyproject_toml,
-    help="Read configuration from `pyproject.toml`.",
+    callback=config.read_config_file,
+    help="Read configuration from `pyproject.toml` or `setup.cfg`.",
 )
 @click.pass_context
 def main(ctx, paths, **kwargs):
@@ -228,6 +228,7 @@ def main(ctx, paths, **kwargs):
     .. versionadded:: 1.2.0 ``--ignore-nested-functions``
     .. versionadded:: 1.2.0 ``--color``/``--no-color``
     .. versionadded:: 1.3.0 ``--ignore-property-decorators``
+    .. versionadded:: 1.3.0 config parsing support for setup.cfg
     """
     if not paths:
         paths = (os.path.abspath(os.getcwd()),)

--- a/tests/functional/test_cli.py
+++ b/tests/functional/test_cli.py
@@ -23,7 +23,7 @@ def runner(monkeypatch):
     """Click fixture runner"""
     # don't let the tests accidentally bring in the project's own
     # pyproject.toml
-    monkeypatch.setattr(config, "find_pyproject_toml", lambda x: None)
+    monkeypatch.setattr(config, "find_project_config", lambda x: None)
     return testing.CliRunner()
 
 

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1,6 +1,7 @@
 # Copyright 2020 Lynn Root
 """Unit tests for interrogate/config.py module"""
 
+import configparser
 import pathlib
 
 import click
@@ -39,14 +40,14 @@ def test_find_project_root(srcs, patch_func, expected, monkeypatch):
 
 @pytest.mark.parametrize(
     "is_file,expected",
-    ((True, str(pathlib.Path("/usr/src/pyproject.toml"))), (False, None)),
+    ((True, str(pathlib.Path("/usr/src/pyproject.toml"))), (False, None),),
 )
-def test_find_pyproject_toml(is_file, expected, mocker, monkeypatch):
-    """Return absolute path if pyproject.toml is detected."""
+def test_find_project_config(is_file, expected, mocker, monkeypatch):
+    """Return absolute path if pyproject.toml or setup.cfg is detected."""
     monkeypatch.setattr(config.pathlib.Path, "is_file", lambda x: is_file)
     monkeypatch.setattr(config.pathlib.Path, "resolve", lambda x: x)
 
-    actual = config.find_pyproject_toml(("/usr/src/app",))
+    actual = config.find_project_config(("/usr/src/app",))
     assert expected == actual
 
 
@@ -66,11 +67,72 @@ def test_parse_pyproject_toml(tmpdir):
     assert {"ignore_init_module": True} == actual
 
 
-def test_read_pyproject_toml_none(mocker, monkeypatch):
-    """Return nothing if no pyproject.toml is found."""
-    monkeypatch.setattr(config, "find_pyproject_toml", lambda x: None)
+@pytest.mark.parametrize(
+    "value,exp_value",
+    (
+        (None, []),
+        ("", []),
+        ("[]", []),
+        ("[foo,bar,baz]", ["foo", "bar", "baz"]),
+        ('["foo","bar","baz"]', ["foo", "bar", "baz"]),
+        ('["foo", "bar", "baz"]', ["foo", "bar", "baz"]),
+        ('"foo", "bar", "baz"', ["foo", "bar", "baz"]),
+        (
+            '"^get$", "^mock_.*", ".*BaseClass.*"',
+            ["^get$", "^mock_.*", ".*BaseClass.*"],
+        ),
+        (
+            "^get$,^mock_.*,.*BaseClass.*",
+            ["^get$", "^mock_.*", ".*BaseClass.*"],
+        ),
+    ),
+)
+def test_sanitize_list_values(value, exp_value):
+    """Return expected list from a string that should be a list."""
+    assert exp_value == config.sanitize_list_values(value)
+
+
+def test_parse_setup_cfg(tmpdir):
+    """Return expected config data from a setup.cfg file."""
+    cfg_data = (
+        "[tool:foo]\n"
+        'foo = "bar"\n'
+        "[tool:interrogate]\n"
+        "ignore-init-module = true\n"
+        "ignore-init-method = false\n"
+        "exclude = foo/bar,baz\n"
+        "output = foo.txt\n"
+    )
+
+    p = tmpdir.mkdir("interrogate-testing").join("setup.cfg")
+    p.write(cfg_data)
+
+    actual = config.parse_setup_cfg(str(p))
+    expected = {
+        "ignore_init_module": True,
+        "ignore_init_method": False,
+        "exclude": ["foo/bar", "baz"],
+        "output": "foo.txt",
+    }
+    assert expected == actual
+
+
+def test_parse_setup_cfg_raises(tmpdir):
+    """Return nothing if no interrogate section was found."""
+    cfg_data = "[tool.foo]\n" 'foo = "bar"\n'
+
+    p = tmpdir.mkdir("interrogate-testing").join("setup.cfg")
+    p.write(cfg_data)
+
+    actual = config.parse_setup_cfg(str(p))
+    assert actual is None
+
+
+def test_read_config_file_none(mocker, monkeypatch):
+    """Return nothing if no pyproject.toml or setup.cfg is found."""
+    monkeypatch.setattr(config, "find_project_config", lambda x: None)
     ctx = mocker.Mock()
-    actual = config.read_pyproject_toml(ctx, "config", None)
+    actual = config.read_config_file(ctx, "config", None)
     assert actual is None
 
 
@@ -78,50 +140,69 @@ def test_read_pyproject_toml_none(mocker, monkeypatch):
     "value,ret_config,default_map,exp_ret,exp_defaults",
     (
         (None, None, None, None, None),
-        ("a-value", {"fail_under": 90}, None, "a-value", {"fail_under": 90}),
-        ("a-value", {"fail_under": 90}, {}, "a-value", {"fail_under": 90}),
         (
-            "a-value",
+            "pyproject.toml",
+            {"fail_under": 90},
+            None,
+            "pyproject.toml",
+            {"fail_under": 90},
+        ),
+        (
+            "setup.cfg",
+            {"fail_under": 90},
+            None,
+            "setup.cfg",
+            {"fail_under": 90},
+        ),
+        ("setup.cfg", {"fail_under": 90}, {}, "setup.cfg", {"fail_under": 90}),
+        (
+            "pyproject.toml",
             {"fail_under": 90},
             {"foo": "bar"},
-            "a-value",
+            "pyproject.toml",
+            {"fail_under": 90, "foo": "bar"},
+        ),
+        (
+            "setup.cfg",
+            {"fail_under": 90},
+            {"foo": "bar"},
+            "setup.cfg",
             {"fail_under": 90, "foo": "bar"},
         ),
         # test backwards config for turning a single regex str (<1.1.3)
         # to a list of regex strs (>=1.1.3)
         (
-            "a-value",
+            "pyproject.toml",
             {"ignore_regex": "^get_.*"},
             None,
-            "a-value",
+            "pyproject.toml",
             {"ignore_regex": ["^get_.*"]},
         ),
         (
-            "a-value",
+            "pyproject.toml",
             {"ignore_regex": ["^get_.*", "^post_.*"]},
             None,
-            "a-value",
+            "pyproject.toml",
             {"ignore_regex": ["^get_.*", "^post_.*"]},
         ),
     ),
 )
-def test_read_pyproject_toml(
+def test_read_config_file(
     value, ret_config, default_map, exp_ret, exp_defaults, mocker, monkeypatch
 ):
-    """Parse config from a given pyproject.toml file."""
-    monkeypatch.setattr(
-        config, "find_pyproject_toml", lambda x: "pyproject.toml"
-    )
+    """Parse config from a given pyproject.toml or setup.cfg file."""
+    monkeypatch.setattr(config, "find_project_config", lambda x: value)
     monkeypatch.setattr(config, "parse_pyproject_toml", lambda x: ret_config)
+    monkeypatch.setattr(config, "parse_setup_cfg", lambda x: ret_config)
     ctx = mocker.Mock(default_map=default_map, params={})
 
-    actual = config.read_pyproject_toml(ctx, "config", value)
+    actual = config.read_config_file(ctx, "config", value)
     assert exp_ret == actual
     assert exp_defaults == ctx.default_map
 
 
-def test_read_pyproject_toml_raises(mocker, monkeypatch):
-    """Handle expected exceptions while reading pyproject.toml, if any."""
+def test_read_config_file_raises(mocker, monkeypatch):
+    """Handle exceptions while reading pyproject.toml/setup.cfg, if any."""
     toml_error = toml.TomlDecodeError("toml error", doc="foo", pos=0)
     os_error = OSError("os error")
     mock_parse_pyproject_toml = mocker.Mock()
@@ -129,11 +210,22 @@ def test_read_pyproject_toml_raises(mocker, monkeypatch):
     monkeypatch.setattr(
         config, "parse_pyproject_toml", mock_parse_pyproject_toml
     )
+    cfg_error = configparser.ParsingError("cfg parsing error")
+    mock_parse_setup_cfg = mocker.Mock()
+    mock_parse_setup_cfg.side_effect = (cfg_error,)
+    monkeypatch.setattr(config, "parse_setup_cfg", mock_parse_setup_cfg)
 
     error_msg = "Error reading configuration file: toml error"
     with pytest.raises(click.FileError, match=error_msg):
-        config.read_pyproject_toml({}, "foo", "bar")
+        config.read_config_file({}, "foo", "pyproject.toml")
 
     error_msg = "Error reading configuration file: os error"
     with pytest.raises(click.FileError, match=error_msg):
-        config.read_pyproject_toml({}, "foo", "bar")
+        config.read_config_file({}, "foo", "pyproject.toml")
+
+    error_msg = (
+        "Error reading configuration file: Source contains parsing errors: "
+        "'cfg parsing error'"
+    )
+    with pytest.raises(click.FileError, match=error_msg):
+        config.read_config_file({}, "foo", "setup.cfg")


### PR DESCRIPTION
# Hey, I just made a Pull Request!

## Description
<!--- Describe your changes -->

Add support for reading configuration from `setup.cfg`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

#35

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." and -->
<!--- "I ran `interrogate` with these changes over some code and it works for me." -->

## Checklist for PR author(s)
<!-- If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing left to do. -->
- [x] Changes are covered by unit tests (no major decrease in code coverage %).
- [x] All tests pass.
- [x] Docstring coverage is **100%** via `tox -e docs` or `interrogate -c pyproject.toml` (I mean, we _should_ set a good example :smile:).
- [x] Updates to documentation:
    - [x] Document any relevant additions/changes in `README.rst`.
    - [x] Manually update **both** the `README.rst` _and_ `docs/index.rst` for any new/changed CLI flags.
    - [x] Any changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/markup/para.html#directive-versionadded).  Find the appropriate next version in the project's [``__init__.py``](https://github.com/econchick/interrogate/blob/master/src/interrogate/__init__.py) file.

## Release note
<!--  If your change is non-trivial (e.g. more than a fixed typo in docs, or updated tests), please write a suggested release note for us to include in `docs/changelog.rst` (we may edit it a bit).

1. Enter your release note in the below block. If the PR requires additional action from users switching to the new release, start the release note with the string "action required: ". Please write it in the imperative.
2. If no release note is required, just write "NONE".
-->
```release-note
 Add support for read configuration from ``setup.cfg``
```

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
