### PR TITLE
Make badge creation lazy 

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -4,4 +4,5 @@
   entry: interrogate
   language: python
   language_version: python3
+  require_serial: true
   types: [python]

--- a/src/interrogate/badge_gen.py
+++ b/src/interrogate/badge_gen.py
@@ -39,8 +39,11 @@ def save_badge(badge, output):
 
     :param str badge: SVG contents of badge.
     :param str output: path to output badge file.
+
     :return: path to output badge file.
     :rtype: str
+
+    .. versionchanged:: 1.4.0 Badge only is written if content changes.
     """
     badge_path = Path(output)
     if not badge_path.suffixes:

--- a/src/interrogate/badge_gen.py
+++ b/src/interrogate/badge_gen.py
@@ -6,7 +6,11 @@ Inspired by `coverage-badge <https://github.com/dbrgn/coverage-badge>`_.
 
 import os
 
+from pathlib import Path
+
 import pkg_resources
+
+from interrogate.utils import multiline_str_is_equal
 
 
 DEFAULT_FILENAME = "interrogate_badge.svg"
@@ -38,13 +42,17 @@ def save_badge(badge, output):
     :return: path to output badge file.
     :rtype: str
     """
-    if os.path.isdir(output):
-        output = os.path.join(output, DEFAULT_FILENAME)
+    badge_path = Path(output)
+    if not badge_path.suffixes:
+        badge_path = badge_path / DEFAULT_FILENAME
+    if not badge_path.is_file():
+        badge_path.write_text(badge, encoding="utf8")
+    elif not multiline_str_is_equal(
+        badge_path.read_text(encoding="utf8"), badge
+    ):
+        badge_path.write_text(badge, encoding="utf8")
 
-    with open(output, "w") as f:
-        f.write(badge)
-
-    return output
+    return str(badge_path)
 
 
 def get_badge(result, color):

--- a/src/interrogate/utils.py
+++ b/src/interrogate/utils.py
@@ -27,6 +27,8 @@ def multiline_str_is_equal(lhs, rhs):
 
     :return: Whether or not the strings are equal.
     :rtype: bool
+
+    .. versionadded:: 1.4.0
     """
     lhs = lhs.replace("\n", "").replace("\r", "")
     rhs = rhs.replace("\n", "").replace("\r", "")

--- a/src/interrogate/utils.py
+++ b/src/interrogate/utils.py
@@ -19,6 +19,20 @@ import colorama
 IS_WINDOWS = sys.platform == "win32"
 
 
+def multiline_str_is_equal(lhs, rhs):
+    """Checks multiline string equality idependent of lineending.
+
+    :param str lhs: Left hand side string.
+    :param str rhs: Right hand side string.
+
+    :return: Whether or not the strings are equal.
+    :rtype: bool
+    """
+    lhs = lhs.replace("\n", "").replace("\r", "")
+    rhs = rhs.replace("\n", "").replace("\r", "")
+    return lhs == rhs
+
+
 def parse_regex(ctx, param, values):
     """Compile a regex if given.
 

--- a/tests/unit/test_badge_gen.py
+++ b/tests/unit/test_badge_gen.py
@@ -1,7 +1,6 @@
 # Copyright 2020 Lynn Root
 """Unit tests for interrogate/badge_gen.py module"""
 
-import os
 import sys
 
 from pathlib import Path
@@ -9,10 +8,11 @@ from pathlib import Path
 import pytest
 
 from interrogate import badge_gen
+from interrogate.utils import multiline_str_is_equal
 
 
-HERE = os.path.abspath(os.path.join(os.path.abspath(__file__), os.path.pardir))
-FIXTURES = os.path.join(HERE, "fixtures")
+HERE = Path(__file__).absolute().parent
+FIXTURES = HERE / "fixtures"
 IS_WINDOWS = sys.platform in ("cygwin", "win32")
 
 
@@ -90,13 +90,11 @@ def test_save_badge_windows(
 def test_get_badge():
     """SVG badge is templated as expected."""
     actual = badge_gen.get_badge(99.9, "#4c1")
-    actual = actual.replace("\n", "").replace("\r", "")
-    expected_fixture = os.path.join(FIXTURES, "99.svg")
-    with open(expected_fixture, "r") as f:
-        expected = f.read()
-        expected = expected.replace("\n", "").replace("\r", "")
 
-    assert expected == actual
+    expected_fixture = FIXTURES / "99.svg"
+    expected = expected_fixture.read_text()
+
+    assert multiline_str_is_equal(expected, actual)
 
 
 @pytest.mark.parametrize(
@@ -132,14 +130,9 @@ def test_create(result, expected_fixture, mocker, monkeypatch, tmpdir):
     """Status badges are created according to interrogation results."""
     mock_result = mocker.Mock(perc_covered=result)
     actual = badge_gen.create(str(tmpdir), mock_result)
+    actual_contents = Path(actual).read_text()
 
-    with open(actual, "r") as f:
-        actual_contents = f.read()
-        actual_contents = actual_contents.replace("\n", "")
+    expected_fixture = FIXTURES / expected_fixture
+    expected_contents = expected_fixture.read_text()
 
-    expected_fixture = os.path.join(FIXTURES, expected_fixture)
-    with open(expected_fixture, "r") as f:
-        expected_contents = f.read()
-        expected_contents = expected_contents.replace("\n", "")
-
-    assert expected_contents == actual_contents
+    assert multiline_str_is_equal(expected_contents, actual_contents)

--- a/tests/unit/test_badge_gen.py
+++ b/tests/unit/test_badge_gen.py
@@ -13,13 +13,29 @@ from interrogate.utils import multiline_str_is_equal
 
 HERE = Path(__file__).absolute().parent
 FIXTURES = HERE / "fixtures"
-IS_WINDOWS = sys.platform in ("cygwin", "win32")
 
 
-def body_test_save_badge(
-    output, expected, file_exists, expected_read, mocker, monkeypatch,
+if sys.platform in ("cygwin", "win32"):
+    SAVE_BADGE_TEST_PATHS = (
+        ("C:\\foo\\bar", "C:\\foo\\bar\\interrogate_badge.svg"),
+        ("C:\\foo\\bar\\my_badge.svg", "C:\\foo\\bar\\my_badge.svg"),
+    )
+else:
+    SAVE_BADGE_TEST_PATHS = (
+        ("foo/bar", "foo/bar/interrogate_badge.svg"),
+        ("foo/bar/my_badge.svg", "foo/bar/my_badge.svg"),
+    )
+
+
+@pytest.mark.parametrize(
+    "expected_read", ["<svg>foo</svg>", "<svg>foo2</svg>"]
+)
+@pytest.mark.parametrize("file_exists", [True, False])
+@pytest.mark.parametrize("output,expected", SAVE_BADGE_TEST_PATHS)
+def test_save_badge(
+    output, expected, file_exists, expected_read, mocker, monkeypatch
 ):
-    """Function body of test_save_badge and test_save_badge_windows"""
+    """Badge is saved in the expected location."""
     monkeypatch.setattr(Path, "is_file", lambda x: file_exists)
     mock_read_text = mocker.Mock(return_value=expected_read)
     monkeypatch.setattr(Path, "read_text", mock_read_text)
@@ -43,48 +59,6 @@ def body_test_save_badge(
         mock_write_text.assert_called_once_with(
             badge_contents, encoding="utf8"
         )
-
-
-@pytest.mark.skipif(IS_WINDOWS, reason="unix-only tests")
-@pytest.mark.parametrize(
-    "expected_read", ["<svg>foo</svg>", "<svg>foo2</svg>"]
-)
-@pytest.mark.parametrize("file_exists", [True, False])
-@pytest.mark.parametrize(
-    "output,expected",
-    (
-        ("foo/bar", "foo/bar/interrogate_badge.svg"),
-        ("foo/bar/my_badge.svg", "foo/bar/my_badge.svg"),
-    ),
-)
-def test_save_badge(
-    output, expected, file_exists, expected_read, mocker, monkeypatch
-):
-    """Badge is saved in the expected location."""
-    body_test_save_badge(
-        output, expected, file_exists, expected_read, mocker, monkeypatch
-    )
-
-
-@pytest.mark.skipif(not IS_WINDOWS, reason="windows-only tests")
-@pytest.mark.parametrize(
-    "expected_read", ["<svg>foo</svg>", "<svg>foo2</svg>"]
-)
-@pytest.mark.parametrize("file_exists", [True, False])
-@pytest.mark.parametrize(
-    "output,expected",
-    (
-        ("C:\\foo\\bar", "C:\\foo\\bar\\interrogate_badge.svg"),
-        ("C:\\foo\\bar\\my_badge.svg", "C:\\foo\\bar\\my_badge.svg"),
-    ),
-)
-def test_save_badge_windows(
-    output, expected, file_exists, expected_read, mocker, monkeypatch
-):
-    """Badge is saved in the expected location."""
-    body_test_save_badge(
-        output, expected, file_exists, expected_read, mocker, monkeypatch
-    )
 
 
 def test_get_badge():

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -15,6 +15,17 @@ IS_PY38 = sys.version_info >= (3, 8)
 
 
 @pytest.mark.parametrize(
+    "lhs", ["foobar", "foo\nbar", "foo\rbar", "foo\r\nbar"]
+)
+@pytest.mark.parametrize(
+    "rhs", ["foobar", "foo\nbar", "foo\rbar", "foo\r\nbar"]
+)
+def test_multiline_str_is_equal(lhs, rhs):
+    assert utils.multiline_str_is_equal(lhs, rhs)
+    assert not utils.multiline_str_is_equal(lhs, rhs + "baz")
+
+
+@pytest.mark.parametrize(
     "value,exp",
     (
         # no regex given


### PR DESCRIPTION
## Description
This PR fixes #40 , by only writing the badge if the content changed (ignoring the line ending).
In the end it got a bit more complex than expected (mainly due to the very extensive testing of `save_badge`, which is really nice 😉 ).

### Only one problem left (That's why this PR is in Draft mode)

What should be done if the path doesn't exist?
i.e. 
```bash
$ interrogate -g docs/_static/dir_does_not_exist <path_to_src>
```

**Behaviour on my branch**:
`FileNotFoundError: [Errno 2] No such file or directory:`

**Behaviour on the master branch**:
It writes a file `dir_does_not_exist ` with the content of the badge.
This is due to the implicit `os.path.exists` check in `os.path.isdir`
https://github.com/econchick/interrogate/blob/5cef2266a4836108f030af1d74f594edeb8c9b10/src/interrogate/badge_gen.py#L41

If the path is more nested:
i.e. 
```bash
$ interrogate -g docs/_static/dir_does_not_exist/also_not_existing <path_to_src>
```
You get the same error.
`FileNotFoundError: [Errno 2] No such file or directory:`

### Possible Solutions
1. Ensure that all parent paths exist by creating them unasked (`os.makedirs`), which IMHO could be dangerous.

1. Throw a custom `BadgePathDoesNotExistError` (maybe right after parsing the CLI and config), that way users know what's wrong and can fix it themselves.

What are your thoughts on this?

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Have you tested this? If so, how?
I have included unit tests.
And I ran `interrogate` with these changes over some code and it works for me ().

## Checklist for PR author(s)
<!-- If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing left to do. -->
- [x] Changes are covered by unit tests (no major decrease in code coverage %).
- [x] All tests pass.
- [x] Docstring coverage is **100%** via `tox -e docs` or `interrogate -c pyproject.toml` (I mean, we _should_ set a good example :smile:).
- [x] Updates to documentation:
    - [ ] Document any relevant additions/changes in `README.rst`.
    - [x] Manually update **both** the `README.rst` _and_ `docs/index.rst` for any new/changed CLI flags.
    - [x] Any changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/markup/para.html#directive-versionadded).  Find the appropriate next version in the project's [``__init__.py``](https://github.com/econchick/interrogate/blob/master/src/interrogate/__init__.py) file.

## Release note
<!--  If your change is non-trivial (e.g. more than a fixed typo in docs, or updated tests), please write a suggested release note for us to include in `docs/changelog.rst` (we may edit it a bit).

1. Enter your release note in the below block. If the PR requires additional action from users switching to the new release, start the release note with the string "action required: ". Please write it in the imperative.
2. If no release note is required, just write "NONE".
-->
```release-note
Badge now is only overwritten if the coverage changed.
```

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
