### PR TITLE
Update tooling

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "sunday"

--- a/.github/workflows/autoupdate-pre-commit-config.yml
+++ b/.github/workflows/autoupdate-pre-commit-config.yml
@@ -1,0 +1,33 @@
+name: "Update pre-commit config"
+# You need to set an access token as a secret ACTION_TRIGGER_TOKEN on this repo
+# in order for the PR to trigger the CI.
+# For more details see: https://github.com/technote-space/create-pr-action#github_token
+# If you don't want the PR to trigger the CI (NOT RECOMMENDED), comment out the GITHUB_TOKEN line.
+
+on:
+  schedule:
+    - cron: "0 7 * * 1" # At 07:00 on each Monday.
+  workflow_dispatch:
+
+jobs:
+  update-pre-commit:
+    name: Autoupdate pre-commit config
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Python
+        uses: actions/setup-python@v2
+      - uses: actions/cache@v2
+        with:
+          path: ~/.cache/pre-commit
+          key: pre-commit-autoupdate
+      - name: Update pre-commit config packages
+        uses: technote-space/create-pr-action@v2
+        with:
+          GITHUB_TOKEN: ${{ secrets.ACTION_TRIGGER_TOKEN }}
+          EXECUTE_COMMANDS: |
+            pip install pre-commit
+            pre-commit autoupdate || (exit 0);
+            pre-commit run -a || (exit 0);
+          COMMIT_MESSAGE: "⬆️ UPGRADE: Autoupdate pre-commit config"
+          PR_BRANCH_NAME: "pre-commit-config-update-${PR_ID}"
+          PR_TITLE: "⬆️ UPGRADE: Autoupdate pre-commit config"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
         python-version: ["3.5", "3.6", "3.7", "3.8"]
     steps:
       - uses: "actions/checkout@v2"
-      - uses: "actions/setup-python@v1"
+      - uses: "actions/setup-python@v2"
         with:
           python-version: "${{ matrix.python-version }}"
       - name: "Install dependencies"
@@ -47,7 +47,7 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - uses: "actions/checkout@v2"
-      - uses: "actions/setup-python@v1"
+      - uses: "actions/setup-python@v2"
         with:
           python-version: "3.8"
       - name: "Install pep517 and twine"
@@ -67,7 +67,7 @@ jobs:
     runs-on: "${{ matrix.os }}"
     steps:
       - uses: "actions/checkout@v2"
-      - uses: "actions/setup-python@v1"
+      - uses: "actions/setup-python@v2"
         with:
           python-version: "3.8"
       - name: "Install in dev mode"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,6 +19,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
+      - name: Locally install interrogate
+        run: python -m pip install .
       - name: Run pre-commit
         uses: pre-commit/action@v2.0.0
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,6 +13,15 @@ on:
     types: rebuild
 
 jobs:
+  pre-commit:
+    name: "Pre-commit"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+      - name: Run pre-commit
+        uses: pre-commit/action@v2.0.0
+
   tests:
     name: "Python ${{ matrix.python-version }} on Ubuntu"
     runs-on: "ubuntu-latest"

--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -21,7 +21,7 @@ jobs:
         python-version: ["3.5", "3.6", "3.7", "3.8"]
     steps:
       - uses: "actions/checkout@v2"
-      - uses: "actions/setup-python@v1"
+      - uses: "actions/setup-python@v2"
         with:
           python-version: "${{ matrix.python-version }}"
       - name: "Install dependencies"
@@ -39,7 +39,7 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - uses: "actions/checkout@v2"
-      - uses: "actions/setup-python@v1"
+      - uses: "actions/setup-python@v2"
         with:
           python-version: "3.8"
       - name: "Install pep517 and twine"
@@ -56,7 +56,7 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - uses: "actions/checkout@v2"
-      - uses: "actions/setup-python@v1"
+      - uses: "actions/setup-python@v2"
         with:
           python-version: "3.8"
       - name: "Install in dev mode"

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -18,7 +18,7 @@ jobs:
         python-version: ["3.5", "3.6", "3.7", "3.8"]
     steps:
       - uses: "actions/checkout@v2"
-      - uses: "actions/setup-python@v1"
+      - uses: "actions/setup-python@v2"
         with:
           python-version: "${{ matrix.python-version }}"
       - name: "Install dependencies"


### PR DESCRIPTION
Just some tooling additions that you might like.
- Update `actions/setup-python` to V2
- Added dependabot config to check for new github action version
- Added `pre-commit` Ci check for quality assurence
- Added workflow to autoupdate `.pre-commit-config.yaml`

## Description
### Changes since `actions/setup-python@v1`
- Improved logs & output when downloading and setting up Python versions
- Improvements and updates to downloading Python versions from actions/python-versions
- Support for pre-release Python distributions
- Fix installation logic to prevent leaving files in GITHUB_WORKSPACE
- Ability to download python packages from actions/python-versions
- Easy setup when using a self-hosted runner
- Support for GHES

For the `pre-commit autoupdate` workflow to work you need to set a secret `ACTION_TRIGGER_TOKEN`, which is an [access token with `repo` or `public_repo` scope](https://github.com/technote-space/create-pr-action#github_token). This is needed in order for the action generated PR's to trigger the CI.

## Motivation and Context
I saw that `actions/setup-python` was still at v1 and that some `pre-commit` repo revisions are outdated, so why not use the latest and greatest? 😄 


## Have you tested this? If so, how?
I'm using a similar/identical setup in my repos 😉 
