### PR TITLE
path exclusion in no longer os-dependent

### DIFF
--- a/src/interrogate/coverage.py
+++ b/src/interrogate/coverage.py
@@ -5,6 +5,8 @@ import os
 import pathlib
 import sys
 
+from fnmatch import fnmatch
+
 import attr
 import click
 import tabulate
@@ -128,9 +130,7 @@ class InterrogateCoverage:
                 basename = os.path.basename(f)
                 if basename == "__init__.py":
                     continue
-            if any(
-                [f.startswith(os.path.normpath(exc)) for exc in self.excluded]
-            ):
+            if any(fnmatch(f, exc + "*") for exc in self.excluded):
                 continue
             yield f
 

--- a/src/interrogate/coverage.py
+++ b/src/interrogate/coverage.py
@@ -128,7 +128,9 @@ class InterrogateCoverage:
                 basename = os.path.basename(f)
                 if basename == "__init__.py":
                     continue
-            if any([f.startswith(os.path.normpath(exc)) for exc in self.excluded]):
+            if any(
+                [f.startswith(os.path.normpath(exc)) for exc in self.excluded]
+            ):
                 continue
             yield f
 

--- a/src/interrogate/coverage.py
+++ b/src/interrogate/coverage.py
@@ -128,11 +128,7 @@ class InterrogateCoverage:
                 basename = os.path.basename(f)
                 if basename == "__init__.py":
                     continue
-            maybe_excluded_dir = any(
-                [f.startswith(exc) for exc in self.excluded]
-            )
-            maybe_excluded_file = f in self.excluded
-            if any([maybe_excluded_dir, maybe_excluded_file]):
+            if any([f.startswith(os.path.normpath(exc)) for exc in self.excluded]):
                 continue
             yield f
 


### PR DESCRIPTION
# Hey, I just made a Pull Request!

## Description
Excluding path is no longer os-dependent, by using `os.path.normpath`.

## Motivation and Context
Fixes #51 

## Have you tested this? If so, how?
I ran `interrogate` with these changes over relevant cases and it works for me.
No additional unit tests required.

## Checklist for PR author(s)
<!-- If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing left to do. -->
- [x] Changes are covered by unit tests (no major decrease in code coverage %).
- [X] All tests pass.
- [X] Docstring coverage is **100%** via `tox -e docs` or `interrogate -c pyproject.toml` (I mean, we _should_ set a good example :smile:).
- [X] Updates to documentation:
    - [X] Document any relevant additions/changes in `README.rst`.
    - [X] Manually update **both** the `README.rst` _and_ `docs/index.rst` for any new/changed CLI flags.
    - [X] Any changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/markup/para.html#directive-versionadded).  Find the appropriate next version in the project's [``__init__.py``](https://github.com/econchick/interrogate/blob/master/src/interrogate/__init__.py) file.
