### PR TITLE
Fix for classifiers not being used in setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -111,4 +111,5 @@ setup(
     install_requires=INSTALL_REQUIRES,
     extras_require=EXTRAS_REQUIRE,
     entry_points={"console_scripts": ["interrogate = interrogate.cli:main"],},
+    classifiers=CLASSIFIERS,
 )


### PR DESCRIPTION
## Description
PyPI classifiers are defined here, but not actually used during setup, so they won't be displayed among metadata on PyPI.

## Motivation and Context
Resolves #61 