### PR TITLE
Missing zero

### DIFF
--- a/src/interrogate/coverage.py
+++ b/src/interrogate/coverage.py
@@ -35,13 +35,16 @@ class BaseInterrogateResult:
     def perc_covered(self):
         """Percentage of node covered.
 
+        .. versionchanged:: 1.3.1
+        A total of 0 translates to 100% coverage now
+
         :return: percentage covered over total.
         :rtype: float
         """
         # Even though empty files each have a total of one,
         # the ignore-module option may still lead to a total of zero.
         if self.total == 0:  # pragma: no cover
-            return 100
+            return 100.0
         return (float(self.covered) / float(self.total)) * 100
 
 

--- a/src/interrogate/coverage.py
+++ b/src/interrogate/coverage.py
@@ -38,10 +38,10 @@ class BaseInterrogateResult:
         :return: percentage covered over total.
         :rtype: float
         """
-        # technically this shouldn't happen since empty files still have
-        # a total of one (module-level)
+        # Even though empty files each have a total of one,
+        # the ignore-module option may still lead to a total of zero.
         if self.total == 0:  # pragma: no cover
-            return 0
+            return 100
         return (float(self.covered) / float(self.total)) * 100
 
 

--- a/tests/functional/test_coverage.py
+++ b/tests/functional/test_coverage.py
@@ -23,7 +23,7 @@ IS_WINDOWS = sys.platform in ("cygwin", "win32")
         (
             [os.path.join(SAMPLE_DIR, "empty.py"),],
             {"ignore_module": True},
-            (0, 0, 0, "0.0"),
+            (0, 0, 0, "100.0"),
         ),
         ([SAMPLE_DIR,], {}, (56, 26, 30, "46.4")),
         ([os.path.join(SAMPLE_DIR, "partial.py")], {}, (22, 7, 15, "31.8")),


### PR DESCRIPTION
# Fix issue #50: a total of 0 should mean SUCCESS instead of failure

## Description
Treat the special case of miss=0 / total=0 as 100% coverage

## Motivation and Context
Fix issue #50 

## Have you tested this? If so, how?
Ran pytest of course, fixed the expectation of 0% coverage for this already specially handled case.
Manual testing: followed the repro steps described in the issue.

## Checklist for PR author(s)
<!-- If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing left to do. -->
- [x] Changes are covered by unit tests (no major decrease in code coverage %).
- [x] All tests pass.
- [x] Docstring coverage is **100%** via `tox -e docs` or `interrogate -c pyproject.toml` (I mean, we _should_ set a good example :smile:).
- [x] Updates to documentation:
    - [x] Document any relevant additions/changes in `README.rst`.
    - [x] Manually update **both** the `README.rst` _and_ `docs/index.rst` for any new/changed CLI flags.
    - [x] Any changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/markup/para.html#directive-versionadded).  Find the appropriate next version in the project's [``__init__.py``](https://github.com/econchick/interrogate/blob/master/src/interrogate/__init__.py) file.

## Release note
<!--  If your change is non-trivial (e.g. more than a fixed typo in docs, or updated tests), please write a suggested release note for us to include in `docs/changelog.rst` (we may edit it a bit).

1. Enter your release note in the below block. If the PR requires additional action from users switching to the new release, start the release note with the string "action required: ". Please write it in the imperative.
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
