### PR TITLE
Add option to just ignore property setters

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -354,6 +354,7 @@ Configure within your ``pyproject.toml`` (``interrogate`` will automatically det
     ignore-module = false
     ignore-nested-functions = false
     ignore-nested-classes = true
+    ignore-setters = false
     fail-under = 95
     exclude = ["setup.py", "docs", "build"]
     ignore-regex = ["^get$", "^mock_.*", ".*BaseClass.*"]
@@ -383,6 +384,7 @@ Or configure within your ``setup.cfg`` (``interrogate`` will automatically detec
     ignore-module = false
     ignore-nested-functions = false
     ignore-nested-classes = true
+    ignore-setters = false
     fail-under = 95
     exclude = setup.py,docs,build
     ignore-regex = ^get$,^mock_.*,.*BaseClass.*
@@ -452,6 +454,9 @@ To view all options available, run ``interrogate --help``:
 
       -P, --ignore-property-decorators
                                       Ignore methods with property setter/getter
+                                      decorators.  [default: False]
+
+      -S, --ignore-setters            Ignore methods with property setter
                                       decorators.  [default: False]
 
       -s, --ignore-semiprivate        Ignore semiprivate classes, methods, and

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -8,7 +8,8 @@ Added
 ^^^^^
 
 * Support for generating the status badge as a PNG file with a new ``--badge-format`` flag (`#70 <https://github.com/econchick/interrogate/issues/70>`_).
-* Add new option ``-C`` / ``--ignore-nested-classess` to ignore – you guessed it – nested classes (`#65 <https://github.com/econchick/interrogate/issues/65>`_).
+* Add new option ``-C`` / ``--ignore-nested-classes` to ignore – you guessed it – nested classes (`#65 <https://github.com/econchick/interrogate/issues/65>`_).
+* Add new option ``-S`` / ``--ignore-setters`` to ignore property setter decorators (`#68 <https://github.com/econchick/interrogate/issues/68>`_).
 
 .. short-log
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -74,6 +74,10 @@ Command Line Options
 
     Ignore methods with property setter/getter decorators.  [default: ``False``]
 
+.. option:: -S, --ignore-setters
+
+    Ignore methods with property setter decorators.  [default: ``False``]
+
 .. option:: -s, --ignore-semiprivate
 
     Ignore semiprivate classes, methods, and functions starting with a single underscore. [default: ``False``]

--- a/src/interrogate/__init__.py
+++ b/src/interrogate/__init__.py
@@ -1,7 +1,7 @@
 # Copyright 2020 Lynn Root
 """Explain yourself! Interrogate a codebase for docstring coverage."""
 __author__ = "Lynn Root"
-__version__ = "1.4.0.dev2"
+__version__ = "1.4.0.dev3"
 __email__ = "lynn@lynnroot.com"
 __description__ = "Interrogate a codebase for docstring coverage."
 __uri__ = "https://interrogate.readthedocs.io"

--- a/src/interrogate/cli.py
+++ b/src/interrogate/cli.py
@@ -133,6 +133,14 @@ from interrogate import utils
     help="Ignore methods with property setter/getter decorators.",
 )
 @click.option(
+    "-S",
+    "--ignore-setters",
+    is_flag=True,
+    default=False,
+    show_default=True,
+    help="Ignore methods with property setter decorators.",
+)
+@click.option(
     "-s",
     "--ignore-semiprivate",
     is_flag=True,
@@ -252,6 +260,7 @@ def main(ctx, paths, **kwargs):
     .. versionadded:: 1.3.0 config parsing support for setup.cfg
     .. versionadded:: 1.4.0 ``--badge-format``
     .. versionadded:: 1.4.0 ``--ignore-nested-classes``
+    .. versionadded:: 1.4.0 ``--ignore-setters``
 
     .. versionchanged:: 1.3.1 only generate badge if results change from
         an existing badge.
@@ -282,6 +291,7 @@ def main(ctx, paths, **kwargs):
         ignore_nested_functions=kwargs["ignore_nested_functions"],
         ignore_nested_classes=kwargs["ignore_nested_classes"],
         ignore_property_decorators=kwargs["ignore_property_decorators"],
+        ignore_property_setters=kwargs["ignore_setters"],
         ignore_private=kwargs["ignore_private"],
         ignore_regex=kwargs["ignore_regex"],
         ignore_semiprivate=kwargs["ignore_semiprivate"],

--- a/src/interrogate/config.py
+++ b/src/interrogate/config.py
@@ -46,6 +46,7 @@ class InterrogateConfig:
     ignore_init_module = attr.ib(default=False)
     ignore_nested_classes = attr.ib(default=False)
     ignore_nested_functions = attr.ib(default=False)
+    ignore_property_setters = attr.ib(default=False)
     ignore_property_decorators = attr.ib(default=False)
     include_regex = attr.ib(default=False)
 

--- a/src/interrogate/visit.py
+++ b/src/interrogate/visit.py
@@ -179,6 +179,17 @@ class CoverageVisitor(ast.NodeVisitor):
                     return True
         return False
 
+    def _has_setters(self, node):
+        """Detect if node has property get/setter decorators."""
+        if not hasattr(node, "decorator_list"):
+            return False
+
+        for dec in node.decorator_list:
+            if hasattr(dec, "attr"):
+                if dec.attr == "setter":
+                    return True
+        return False
+
     def _is_func_ignored(self, node):
         """Should the AST visitor ignore this func/method node."""
         is_init = node.name == "__init__"
@@ -190,12 +201,15 @@ class CoverageVisitor(ast.NodeVisitor):
             ]
         )
         has_property_decorators = self._has_property_decorators(node)
+        has_setters = self._has_setters(node)
 
         if self.config.ignore_init_method and is_init:
             return True
         if self.config.ignore_magic and is_magic:
             return True
         if self.config.ignore_property_decorators and has_property_decorators:
+            return True
+        if self.config.ignore_property_setters and has_setters:
             return True
 
         return self._is_ignored_common(node)

--- a/tests/functional/test_cli.py
+++ b/tests/functional/test_cli.py
@@ -52,6 +52,8 @@ def test_run_no_paths(runner, monkeypatch, tmpdir):
         (["-p"], 48.0, 1),
         # ignore property getter/setter decorators
         (["-P"], 46.2, 1),
+        # ignore property setter decorators
+        (["-S"], 46.3, 1),
         # ignore magic method docs
         (["-m"], 46.2, 1),
         # ignore init method docs
@@ -90,6 +92,7 @@ def test_run_shortflags(flags, exp_result, exp_exit_code, runner):
         (["--ignore-semiprivate"], 46.9, 1),
         (["--ignore-private"], 48.0, 1),
         (["--ignore-property-decorators"], 46.2, 1),
+        (["--ignore-setters"], 46.3, 1),
         (["--ignore-magic"], 46.2, 1),
         (["--ignore-init-method"], 45.3, 1),
         (["--ignore-nested-functions"], 45.3, 1),


### PR DESCRIPTION
# Hey, I just made a Pull Request!

## Description
<!--- Describe your changes -->

Add new options `-S` / `--ignore-setters` option to ignore property setters.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

#68

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." and -->
<!--- "I ran `interrogate` with these changes over some code and it works for me." -->

## Checklist for PR author(s)
<!-- If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing left to do. -->
- [x] Changes are covered by unit tests (no major decrease in code coverage %).
- [x] All tests pass.
- [x] Docstring coverage is **100%** via `tox -e docs` or `interrogate -c pyproject.toml` (I mean, we _should_ set a good example :smile:).
- [x] Updates to documentation:
    - [x] Document any relevant additions/changes in `README.rst`.
    - [x] Manually update **both** the `README.rst` _and_ `docs/index.rst` for any new/changed CLI flags.
    - [x] Any changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/markup/para.html#directive-versionadded).  Find the appropriate next version in the project's [``__init__.py``](https://github.com/econchick/interrogate/blob/master/src/interrogate/__init__.py) file.

## Release note
<!--  If your change is non-trivial (e.g. more than a fixed typo in docs, or updated tests), please write a suggested release note for us to include in `docs/changelog.rst` (we may edit it a bit).

1. Enter your release note in the below block. If the PR requires additional action from users switching to the new release, start the release note with the string "action required: ". Please write it in the imperative.
2. If no release note is required, just write "NONE".
-->
```release-note

```

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
