### PR TITLE
Add a lower bound to Click

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,7 @@ CLASSIFIERS = [
 ]
 INSTALL_REQUIRES = [
     "attrs",
-    "click>=7.0",
+    "click>=7.1",
     "colorama",
     "py",
     "tabulate",

--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,7 @@ CLASSIFIERS = [
 ]
 INSTALL_REQUIRES = [
     "attrs",
-    "click",
+    "click>=7.0",
     "colorama",
     "py",
     "tabulate",


### PR DESCRIPTION
# Minor packaging update

## Description
This adds a lower version bound on Click corresponding to the features that interrogate uses.

## Motivation and Context

Context is here: https://github.com/econchick/interrogate/issues/81

tl;dr; I got stung by this gotcha and thought this might be a useful update for others

## Have you tested this? If so, how?
* created a virtualenv
* ran: `pip install click==6.7`
* ran: `pip install -e .`
* observed that pip uninstalled the old click and upgraded it 

## Checklist for PR author(s)
- [x] Changes are covered by unit tests (no major decrease in code coverage %).
- [x] All tests pass.
- [x] Docstring coverage is **100%** via `tox -e docs` or `interrogate -c pyproject.toml` (I mean, we _should_ set a good example :smile:).
- [x] Updates to documentation:
    - [x] Document any relevant additions/changes in `README.rst`.
    - [x] Manually update **both** the `README.rst` _and_ `docs/index.rst` for any new/changed CLI flags.
    - [x] Any changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/markup/para.html#directive-versionadded).  Find the appropriate next version in the project's [``__init__.py``](https://github.com/econchick/interrogate/blob/master/src/interrogate/__init__.py) file.

## Release note
```release-note

    NONE
```