### PR TITLE
Improve documentation on verbose config

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -370,6 +370,7 @@ Configure within your ``pyproject.toml`` (``interrogate`` will automatically det
     fail-under = 95
     exclude = ["setup.py", "docs", "build"]
     ignore-regex = ["^get$", "^mock_.*", ".*BaseClass.*"]
+    # possible values: 0 (minimal output), 1 (-v), 2 (-vv)
     verbose = 0
     quiet = false
     whitelist-regex = []
@@ -401,6 +402,7 @@ Or configure within your ``setup.cfg`` (``interrogate`` will automatically detec
     fail-under = 95
     exclude = setup.py,docs,build
     ignore-regex = ^get$,^mock_.*,.*BaseClass.*
+    ; possible values: 0 (minimal output), 1 (-v), 2 (-vv)
     verbose = 0
     quiet = false
     whitelist-regex =
@@ -428,7 +430,13 @@ To view all options available, run ``interrogate --help``:
 
     Options:
       --version                       Show the version and exit.
-      -v, --verbose                   Level of verbosity  [default: 0]
+      -v, --verbose                   Level of verbosity.
+
+                                      NOTE: When configuring verbosity in
+                                      pyproject.toml or setup.cfg, `verbose=1`
+                                      maps to `-v`, and `verbose=2` maps to `-vv`.
+                                      `verbose=0` is the equivalent of no verbose
+                                      flags used, producing minimal output.
       -q, --quiet                     Do not print output  [default: False]
       -f, --fail-under INT | FLOAT    Fail when coverage % is less than a given
                                       amount.  [default: 80.0]

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,8 +4,9 @@ Changelog
 1.5.0 (UNRELEASED)
 ------------------
 
-* Set minimum ``click`` version (thank you bildzeitung! `#81 <https://github.com/econchick/interrogate/issues/81>`_, `#82 <https://github.com/econchick/interrogate/pull/82>`_)
-* Add ``--omit-covered-files`` flag to skip reporting fully-covered files (`#85 <https://github.com/econchick/interrogate/issues/85>`_)
+* Set minimum ``click`` version (thank you bildzeitung! `#81 <https://github.com/econchick/interrogate/issues/81>`_, `#82 <https://github.com/econchick/interrogate/pull/82>`_).
+* Add ``--omit-covered-files`` flag to skip reporting fully-covered files (`#85 <https://github.com/econchick/interrogate/issues/85>`_).
+* Clarify ``verbose`` configuration (`#83 <https://github.com/econchick/interrogate/issues/83>`_).
 
 .. short-log
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -24,7 +24,11 @@ Command Line Options
 
 .. option:: -v, --verbose
 
-    Level of verbosity  [default: ``0``]
+    Level of verbosity.
+
+    NOTE: When configuring verbosity in ``pyproject.toml`` or ``setup.cfg``,
+    ``verbose=1`` maps to ``-v``, and ``verbose=2`` maps to ``-vv``.
+    ``verbose=0`` is the equivalent of no verbose flags used, producing minimal output.
 
 .. option:: -q, --quiet
 
@@ -100,12 +104,12 @@ Command Line Options
 
 .. option:: --color, --no-color
 
-  Toggle color output on/off when printing to stdout.  [default: color]
+    Toggle color output on/off when printing to stdout.  [default: color]
 
 .. option:: --omit-covered-files
 
-  Omit reporting files that have 100% documentation coverage.
-  This option is ignored if verbosity is not set.  [default: ``False``]
+    Omit reporting files that have 100% documentation coverage.
+    This option is ignored if verbosity is not set.  [default: ``False``]
 
 .. option:: -g, --generate-badge PATH
 

--- a/src/interrogate/cli.py
+++ b/src/interrogate/cli.py
@@ -21,8 +21,14 @@ from interrogate import utils
     "--verbose",
     default=0,
     count=True,
-    show_default=True,
-    help="Level of verbosity",
+    show_default=False,
+    help=(
+        "Level of verbosity."
+        "\n\nNOTE: When configuring verbosity in pyproject.toml or setup.cfg, "
+        "`verbose=1` maps to `-v`, and `verbose=2` maps to `-vv`. "
+        "`verbose=0` is the equivalent of no verbose flags used, producing "
+        "minimal output."
+    ),
 )
 @click.option(
     "-q",


### PR DESCRIPTION
Addresses issue #83

# Hey, I just made a Pull Request!

## Description
<!--- Describe your changes -->

Clarify `verbose` configuration

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." and -->
<!--- "I ran `interrogate` with these changes over some code and it works for me." -->

## Checklist for PR author(s)
<!-- If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing left to do. -->
- [ ] Changes are covered by unit tests (no major decrease in code coverage %).
- [ ] All tests pass.
- [ ] Docstring coverage is **100%** via `tox -e docs` or `interrogate -c pyproject.toml` (I mean, we _should_ set a good example :smile:).
- [ ] Updates to documentation:
    - [ ] Document any relevant additions/changes in `README.rst`.
    - [ ] Manually update **both** the `README.rst` _and_ `docs/index.rst` for any new/changed CLI flags.
    - [ ] Any changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/markup/para.html#directive-versionadded).  Find the appropriate next version in the project's [``__init__.py``](https://github.com/econchick/interrogate/blob/master/src/interrogate/__init__.py) file.

## Release note
<!--  If your change is non-trivial (e.g. more than a fixed typo in docs, or updated tests), please write a suggested release note for us to include in `docs/changelog.rst` (we may edit it a bit).

1. Enter your release note in the below block. If the PR requires additional action from users switching to the new release, start the release note with the string "action required: ". Please write it in the imperative.
2. If no release note is required, just write "NONE".
-->
```release-note

```

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
