### PR TITLE
Fix `tests/unit/test_config.py::test_find_project_config` in pytest 7.0

### DIFF
--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -28,14 +28,15 @@ from interrogate import config
 )
 def test_find_project_root(srcs, patch_func, expected, monkeypatch):
     """Return expected directory of project root."""
-    expected = pathlib.Path(expected)
-    if patch_func:
-        monkeypatch.setattr(config.pathlib.Path, patch_func, lambda x: True)
-    monkeypatch.setattr(config.pathlib.Path, "resolve", lambda x: x)
+    with monkeypatch.context() as mp:
+        expected = pathlib.Path(expected)
+        if patch_func:
+            mp.setattr(config.pathlib.Path, patch_func, lambda x: True)
+        mp.setattr(config.pathlib.Path, "resolve", lambda x: x)
 
-    actual = config.find_project_root(srcs)
+        actual = config.find_project_root(srcs)
 
-    assert expected == actual
+        assert expected == actual
 
 
 @pytest.mark.parametrize(
@@ -47,11 +48,12 @@ def test_find_project_root(srcs, patch_func, expected, monkeypatch):
 )
 def test_find_project_config(is_file, expected, mocker, monkeypatch):
     """Return absolute path if pyproject.toml or setup.cfg is detected."""
-    monkeypatch.setattr(config.pathlib.Path, "is_file", lambda x: is_file)
-    monkeypatch.setattr(config.pathlib.Path, "resolve", lambda x: x)
+    with monkeypatch.context() as mp:
+        mp.setattr(config.pathlib.Path, "is_file", lambda x: is_file)
+        mp.setattr(config.pathlib.Path, "resolve", lambda x: x)
 
-    actual = config.find_project_config(("/usr/src/app",))
-    assert expected == actual
+        actual = config.find_project_config(("/usr/src/app",))
+        assert expected == actual
 
 
 def test_parse_pyproject_toml(tmpdir):


### PR DESCRIPTION
# Hey, I just made a Pull Request!

## Description

pytest 7.0 uses pathlib more itself and this patching ends up
interfering with it in some way. So scope the patching to the test
itself which avoids it affecting pytest itself.

## Motivation and Context

pytest upstream testing pytest 7.0.0rc1: https://github.com/pytest-dev/pytest/discussions/9415

## Have you tested this? If so, how?

Ran tox with pytest 7.0.0rc1.

## Checklist for PR author(s)

- [x] Changes are covered by unit tests (no major decrease in code coverage %).
- [x] All tests pass.
- [x] Docstring coverage is **100%** via `tox -e docs` or `interrogate -c pyproject.toml` (I mean, we _should_ set a good example :smile:).
- [x] Updates to documentation:
    - [x] Document any relevant additions/changes in `README.rst`.
    - [x] Manually update **both** the `README.rst` _and_ `docs/index.rst` for any new/changed CLI flags.
    - [x] Any changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/markup/para.html#directive-versionadded).  Find the appropriate next version in the project's [``__init__.py``](https://github.com/econchick/interrogate/blob/master/src/interrogate/__init__.py) file.

## Release note
<!--  If your change is non-trivial (e.g. more than a fixed typo in docs, or updated tests), please write a suggested release note for us to include in `docs/changelog.rst` (we may edit it a bit).

1. Enter your release note in the below block. If the PR requires additional action from users switching to the new release, start the release note with the string "action required: ". Please write it in the imperative.
2. If no release note is required, just write "NONE".
-->
```release-note
The test suite now runs cleanly under pytest 7.
```

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
