### PR TITLE
Change --omit-covered from 100% coverage to --fail-under value

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -532,7 +532,7 @@ To view all options available, run ``interrogate --help``:
       --color / --no-color            Toggle color output on/off when printing to
                                       stdout.  [default: True]
 
-      --omit-covered-files            Omit reporting files that have 100%
+      --omit-covered-files            Omit reporting files that meet --fail-under
                                       documentation coverage. This option is
                                       ignored if verbosity is not set.  [default:
                                       False]

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -108,7 +108,7 @@ Command Line Options
 
 .. option:: --omit-covered-files
 
-    Omit reporting files that have 100% documentation coverage.
+    Omit reporting files that meet --fail-under documentation coverage.
     This option is ignored if verbosity is not set.  [default: ``False``]
 
 .. option:: -g, --generate-badge PATH

--- a/src/interrogate/cli.py
+++ b/src/interrogate/cli.py
@@ -203,7 +203,7 @@ from interrogate import utils
     default=False,
     show_default=True,
     help=(
-        "Omit reporting files that have 100% documentation coverage. This "
+        "Omit reporting files that meet coverage threshold. This "
         "option is ignored if verbosity is not set."
     ),
 )

--- a/src/interrogate/cli.py
+++ b/src/interrogate/cli.py
@@ -203,8 +203,8 @@ from interrogate import utils
     default=False,
     show_default=True,
     help=(
-        "Omit reporting files that meet coverage threshold. This "
-        "option is ignored if verbosity is not set."
+        "Omit reporting files that meet --fail-under documentation coverage. "
+        "This option is ignored if verbosity is not set."
     ),
 )
 @click.option(

--- a/src/interrogate/config.py
+++ b/src/interrogate/config.py
@@ -37,8 +37,8 @@ class InterrogateConfig:
     :param bool ignore_init_module: Ignore ``__init__.py`` modules.
     :param str include_regex: Regex identifying class, method, and
         function names to include.
-    :param bool omit_covered_files: Omit reporting files that meet coverage
-        threshold coverage.
+    :param bool omit_covered_files: Omit reporting files that meet --fail-under
+        documentation coverage.
     """
 
     color = attr.ib(default=False)

--- a/src/interrogate/config.py
+++ b/src/interrogate/config.py
@@ -37,8 +37,8 @@ class InterrogateConfig:
     :param bool ignore_init_module: Ignore ``__init__.py`` modules.
     :param str include_regex: Regex identifying class, method, and
         function names to include.
-    :param bool omit_covered_files: Omit reporting files that have 100%
-        documentation coverage.
+    :param bool omit_covered_files: Omit reporting files that meet coverage
+        threshold coverage.
     """
 
     color = attr.ib(default=False)

--- a/src/interrogate/coverage.py
+++ b/src/interrogate/coverage.py
@@ -316,7 +316,8 @@ class InterrogateCoverage:
         """Print detailed table to the given output stream."""
         detailed_table = self._create_detailed_table(results)
 
-        # don't print an empty table if --omit-covered & all files have 100%
+        # don't print an empty table if --omit-covered & all files meet 
+        # --fail-under
         if len(detailed_table) < 3:
             return
 
@@ -436,7 +437,7 @@ class InterrogateCoverage:
         return base + "/"
 
     def _print_omitted_file_count(self, results):
-        """Print # of files omitted due to 100% coverage and --omit-covered.
+        """Print # of files omitted due to --fail-under and --omit-covered.
 
         :param InterrogateResults results: results of docstring coverage
             interrogation.
@@ -445,7 +446,7 @@ class InterrogateCoverage:
             return
 
         omitted_files = [
-            r for r in results.file_results if r.perc_covered == 100
+            r for r in results.file_results if r.perc_covered >= self.config.fail_under
         ]
         omitted_file_count = len(omitted_files)
         if omitted_file_count == 0:
@@ -455,7 +456,7 @@ class InterrogateCoverage:
         files_humanized = "files" if total_files_scanned > 1 else "file"
         files_skipped = (
             f"({omitted_file_count} of {total_files_scanned} {files_humanized} "
-            "omitted due to complete coverage)"
+            "omitted due to met coverage)"
         )
         to_print = tabulate.tabulate(
             [self.output_formatter.TABLE_SEPARATOR, [files_skipped]],

--- a/src/interrogate/coverage.py
+++ b/src/interrogate/coverage.py
@@ -300,7 +300,7 @@ class InterrogateCoverage:
         for file_result in combined_results.file_results:
             if (
                 self.config.omit_covered_files
-                and file_result.perc_covered == 100
+                and file_result.perc_covered >= self.config.fail_under
             ):
                 continue
             nodes = file_result.nodes
@@ -350,7 +350,7 @@ class InterrogateCoverage:
             filename = self._get_filename(file_result.filename)
             if (
                 self.config.omit_covered_files
-                and file_result.perc_covered == 100
+                and file_result.perc_covered >= self.config.fail_under
             ):
                 continue
             perc_covered = "{:.0f}%".format(file_result.perc_covered)


### PR DESCRIPTION
# Hey, I just made a Pull Request!

## Description
Change --omit-covered from 100% coverage to --fail-under value

## Motivation and Context
--omit-covered currently only hides 100% covered files even when --fail-under sets another value

## Have you tested this? If so, how?

Ran interrogate with the changes and they seem to work.

## Checklist for PR author(s)
- [x] Changes are covered by unit tests (no major decrease in code coverage %).
- [ ] All tests pass.
  No, but already before my changes.
- [x] Docstring coverage is **100%** via `tox -e docs` or `interrogate -c pyproject.toml` (I mean, we _should_ set a good example :smile:).
- [x] Updates to documentation:
    - [x] Document any relevant additions/changes in `README.rst`.
    - [x] Manually update **both** the `README.rst` _and_ `docs/index.rst` for any new/changed CLI flags.
    - [x] Any changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/markup/para.html#directive-versionadded).  Find the appropriate next version in the project's [``__init__.py``](https://github.com/econchick/interrogate/blob/master/src/interrogate/__init__.py) file.

## Release note
<!--  If your change is non-trivial (e.g. more than a fixed typo in docs, or updated tests), please write a suggested release note for us to include in `docs/changelog.rst` (we may edit it a bit).

1. Enter your release note in the below block. If the PR requires additional action from users switching to the new release, start the release note with the string "action required: ". Please write it in the imperative.
2. If no release note is required, just write "NONE".
-->
```release-note
Change --omit-covered from absolute coverage of 100% to relative coverage based on --fail-under
```

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
