### PR TITLE
Add support for explicitly interrogating .pyi files.

### DIFF
--- a/src/interrogate/coverage.py
+++ b/src/interrogate/coverage.py
@@ -143,9 +143,9 @@ class InterrogateCoverage:
         filenames = []
         for path in self.paths:
             if os.path.isfile(path):
-                if not path.endswith(".py"):
+                if not path.endswith(".py") and not path.endswith(".pyi"):
                     msg = (
-                        "E: Invalid file '{}'. Unable interrogate non-Python "
+                        "E: Invalid file '{}'. Unable to interrogate non-Python "
                         "files.".format(path)
                     )
                     click.echo(msg, err=True)


### PR DESCRIPTION
In some cases, it may be useful to interrogate [.pyi files](https://mypy.readthedocs.io/en/stable/stubs.html) (i.e.: when checking docstring coverage of native Pybind11 modules). Interrogate can parse these files, but refuses to due to a file extension check.

This PR adds a quick patch to work around the issue, while also fixing a typo in an error message. Note that this will _not_ automatically pick up .pyi files in directory trees; .pyi files will only be parsed when passed explicitly to `interrogate` as filenames.