### PR TITLE
Document configuration required to allow file exclusion via config file

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -322,6 +322,7 @@ Or use it with `pre-commit <https://pre-commit.com/>`_:
         hooks:
           - id: interrogate
             args: [--quiet, --fail-under=95]
+            pass_filenames: false  # needed if excluding files with pyproject.toml or setup.cfg
 
 Use it within your code directly:
 


### PR DESCRIPTION
## Description
  
This adds a line to the README to clear up a common point of confusion.

## Motivation and Context

pre-commit passes all source files as arguments to interrogate. Interrogate ignores any exclusion criteria in pyproject.toml or setup.cfg for files that are specified in this way. This gives the appearance that interrogate is ignoring configuration options. This has led to a number of issues, in particular #60, #100, #145, #155, and possibly #128.

## Have you tested this? If so, how?

I have used this exact line in my own project and it works as intended.

## Checklist for PR author(s)

- [x] Changes are covered by unit tests (no major decrease in code coverage %).
- [x] All tests pass.
- [x] Docstring coverage is **100%** via `tox -e docs` or `interrogate -c pyproject.toml` (I mean, we _should_ set a good example :smile:).
- [x] Updates to documentation:
    - [x] Document any relevant additions/changes in `README.rst`.
    - [x] Manually update **both** the `README.rst` _and_ `docs/index.rst` for any new/changed CLI flags.
    - [x] Any changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/markup/para.html#directive-versionadded).  Find the appropriate next version in the project's [``__init__.py``](https://github.com/econchick/interrogate/blob/master/src/interrogate/__init__.py) file.

## Release note

```release-note
NONE
```