### PR TITLE
feat(pre-commit-hooks): add setuptools to additional dependencies

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -6,3 +6,4 @@
   language_version: python3
   types: [python]
   require_serial: true
+  additional_dependencies: [setuptools]


### PR DESCRIPTION
# Hey, I just made a Pull Request!

## Description

This PR adds setuptools to the additional dependencies in the pre-commit-hooks.yaml file.
This change ensures that setuptools is available during the execution of pre-commit hooks,
which can be crucial for certain Python hooks that rely on setuptools.

## Motivation and Context

Resolves #162

## Have you tested this? If so, how?

I have not yet tested this change, but based on reading the documentation, I have moderately high confidence that this is the right fix for #162.

## Checklist for PR author(s)

- [x] Changes are covered by unit tests (no major decrease in code coverage %).
- [x] All tests pass.
- [x] Docstring coverage is **100%** via `tox -e docs` or `interrogate -c pyproject.toml` (I mean, we _should_ set a good example :smile:).
- [x] Updates to documentation:
    - [x] Document any relevant additions/changes in `README.rst`.
    - [x] Manually update **both** the `README.rst` _and_ `docs/index.rst` for any new/changed CLI flags.
    - [x] Any changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/markup/para.html#directive-versionadded).  Find the appropriate next version in the project's [``__init__.py``](https://github.com/econchick/interrogate/blob/master/src/interrogate/__init__.py) file.

## Release note

```release-note
Add `setuptools` to the additional dependencies in the pre-commit-hooks.yaml file.
This change ensures that setuptools is available during the execution of pre-commit hooks,
which is explictly needed when running with Python 3.12.
```