### PR TITLE
Wheel is not necessary as a build requires

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=40.6.0", "wheel"]
+requires = ["setuptools>=40.6.0"]
 build-backend = "setuptools.build_meta"
 
 [tool.check-wheel-contents]


### PR DESCRIPTION
... and modern setuptools documentation advises against adding it
