### PR TITLE
Quote `interrogate[png]` in installation instructions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -69,7 +69,7 @@ To generate a **PNG file** instead, install ``interrogate`` with the extras ``[p
 
 .. code-block:: console
 
-    $ pip install interrogate[png]
+    $ pip install "interrogate[png]"
 
 **NOTICE:** Additional system libraries/tools may be required in order to generate a PNG file of the coverage badge:
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -137,7 +137,7 @@ Command Line Options
     File format for the generated badge. Used with the ``-g/--generate-badge`` flag.  [default: ``svg``]
 
     NOTE: To generate a PNG file, interrogate must be installed with ``interrogate[png]``, i.e.
-    ``pip install interrogate[png]``.
+    ``pip install "interrogate[png]"``.
 
 .. option:: --badge-style [flat|flat-square|flat-square-modified|for-the-badge|plastic|social]
 


### PR DESCRIPTION
# Hey, I just made a Pull Request!

## Description
<!--- Describe your changes -->
Quoted `interrogate[png]` in `pip install interrogate[png]`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
In Z shell, square brackets trigger pattern matching. That may cause this to happen:

```
$ pip install interrogate[png]
zsh: no matches found: interrogate[png]
```

The quoted version is the most universal.