### PR TITLE
Replaced `os.path` with `pathlib`

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,5 +1,6 @@
 import codecs
 import re
+
 from pathlib import Path
 
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,6 +1,6 @@
 import codecs
-import os
 import re
+from pathlib import Path
 
 
 def read(*parts):
@@ -8,8 +8,8 @@ def read(*parts):
     Build an absolute path from *parts* and and return the contents of the
     resulting file.  Assume UTF-8 encoding.
     """
-    here = os.path.abspath(os.path.dirname(__file__))
-    with codecs.open(os.path.join(here, *parts), "rb", "utf-8") as f:
+    here = Path(__file__).parent.absolute()
+    with codecs.open(str(here.joinpath(*parts)), "rb", "utf-8") as f:
         return f.read()
 
 

--- a/setup.py
+++ b/setup.py
@@ -2,13 +2,13 @@
 # Copyright 2020 Lynn Root
 
 import codecs
-import os
 import re
+from pathlib import Path
 
 from setuptools import find_packages, setup
 
 
-HERE = os.path.abspath(os.path.dirname(__file__))
+HERE = Path(__file__).parent.absolute()
 
 
 #####
@@ -23,7 +23,7 @@ def read(*filenames, **kwargs):
     sep = kwargs.get("sep", "\n")
     buf = []
     for fl in filenames:
-        with codecs.open(os.path.join(HERE, fl), "rb", encoding) as f:
+        with codecs.open(HERE / fl, "rb", encoding) as f:
             buf.append(f.read())
     return sep.join(buf)
 
@@ -43,7 +43,7 @@ def find_meta(meta):
 NAME = "interrogate"
 PACKAGE_NAME = "interrogate"
 PACKAGES = find_packages(where="src")
-META_PATH = os.path.join("src", PACKAGE_NAME, "__init__.py")
+META_PATH = Path("src") / PACKAGE_NAME / "__init__.py"
 
 META_FILE = read(META_PATH)
 KEYWORDS = ["documentation", "coverage", "quality"]

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,7 @@
 
 import codecs
 import re
+
 from pathlib import Path
 
 from setuptools import find_packages, setup

--- a/src/interrogate/badge_gen.py
+++ b/src/interrogate/badge_gen.py
@@ -6,11 +6,12 @@ Inspired by `coverage-badge <https://github.com/dbrgn/coverage-badge>`_.
 from __future__ import annotations
 
 import sys
-from pathlib import Path
 
 from importlib import resources
+from pathlib import Path
 from typing import TYPE_CHECKING, Union
 from xml.dom import minidom
+
 
 if TYPE_CHECKING:
     from os import PathLike
@@ -183,7 +184,9 @@ def get_badge(result: float, color: str, style: str | None = None) -> str:
     return tmpl
 
 
-def should_generate_badge(output: PathLike[str] | str, color: str, result: float) -> bool:
+def should_generate_badge(
+    output: PathLike[str] | str, color: str, result: float
+) -> bool:
     """Detect if existing badge needs updating.
 
     This is to help avoid unnecessary newline updates. See

--- a/src/interrogate/cli.py
+++ b/src/interrogate/cli.py
@@ -1,7 +1,7 @@
 # Copyright 2020-2024 Lynn Root
 """CLI entrypoint into `interrogate`."""
 
-import os
+from pathlib import Path
 import sys
 
 from typing import List, Optional, Pattern, Tuple, Union
@@ -218,6 +218,13 @@ from interrogate import coverage, utils
 @click.option(
     "-o",
     "--output",
+    type=click.Path(
+        exists=False,
+        file_okay=True,
+        dir_okay=True,
+        writable=True,
+        resolve_path=True,
+    ),
     default=None,
     metavar="FILE",
     help="Write output to a given FILE.  [default: stdout]",
@@ -313,7 +320,7 @@ from interrogate import coverage, utils
     help="Read configuration from `pyproject.toml` or `setup.cfg`.",
 )
 def main(
-    paths: Optional[List[str]],
+    paths: Optional[List[Path]],
     verbose: int,
     quiet: bool,
     fail_under: Union[int, float],
@@ -389,7 +396,7 @@ def main(
             ),
         )
     if not paths:
-        paths = [os.path.abspath(os.getcwd())]
+        paths = [Path.cwd()]
 
     # NOTE: this will need to be fixed if we want to start supporting
     #       --whitelist-regex on filenames. This otherwise assumes you

--- a/src/interrogate/cli.py
+++ b/src/interrogate/cli.py
@@ -1,9 +1,9 @@
 # Copyright 2020-2024 Lynn Root
 """CLI entrypoint into `interrogate`."""
 
-from pathlib import Path
 import sys
 
+from pathlib import Path
 from typing import List, Optional, Pattern, Tuple, Union
 
 import click

--- a/src/interrogate/config.py
+++ b/src/interrogate/config.py
@@ -16,6 +16,7 @@ from typing import TYPE_CHECKING, Any
 import attr
 import click
 
+
 if TYPE_CHECKING:
     from os import PathLike
 
@@ -115,7 +116,9 @@ def find_project_root(srcs: Sequence[PathLike[str] | str]) -> Path:
     return directory
 
 
-def find_project_config(path_search_start: Sequence[PathLike[str] | str]) -> str | None:
+def find_project_config(
+    path_search_start: Sequence[PathLike[str] | str],
+) -> str | None:
     """Find the absolute filepath to a pyproject.toml if it exists."""
     project_root = find_project_root(path_search_start)
     pyproject_toml = project_root / "pyproject.toml"

--- a/src/interrogate/config.py
+++ b/src/interrogate/config.py
@@ -7,16 +7,17 @@ Configuration-related helpers.
 from __future__ import annotations
 
 import configparser
-import os
-import pathlib
 import re
 
 from collections.abc import Sequence
-from typing import Any
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
 
 import attr
 import click
 
+if TYPE_CHECKING:
+    from os import PathLike
 
 try:
     import tomllib
@@ -86,7 +87,7 @@ class InterrogateConfig:
             )
 
 
-def find_project_root(srcs: Sequence[str]) -> pathlib.Path:
+def find_project_root(srcs: Sequence[PathLike[str] | str]) -> Path:
     """Return a directory containing .git, .hg, or pyproject.toml.
     That directory can be one of the directories passed in `srcs` or their
     common parent.
@@ -94,9 +95,9 @@ def find_project_root(srcs: Sequence[str]) -> pathlib.Path:
     project root, the root of the file system is returned.
     """
     if not srcs:
-        return pathlib.Path("/").resolve()
+        return Path("/").resolve()
 
-    common_base = min(pathlib.Path(src).resolve() for src in srcs)
+    common_base = min(Path(src).resolve() for src in srcs)
     if common_base.is_dir():
         # Append a fake file so `parents` below returns `common_base_dir`, too.
         common_base /= "fake-file"
@@ -114,7 +115,7 @@ def find_project_root(srcs: Sequence[str]) -> pathlib.Path:
     return directory
 
 
-def find_project_config(path_search_start: Sequence[str]) -> str | None:
+def find_project_config(path_search_start: Sequence[PathLike[str] | str]) -> str | None:
     """Find the absolute filepath to a pyproject.toml if it exists."""
     project_root = find_project_root(path_search_start)
     pyproject_toml = project_root / "pyproject.toml"
@@ -125,7 +126,7 @@ def find_project_config(path_search_start: Sequence[str]) -> str | None:
     return str(setup_cfg) if setup_cfg.is_file() else None
 
 
-def parse_pyproject_toml(path_config: str) -> dict[str, Any]:
+def parse_pyproject_toml(path_config: PathLike[str] | str) -> dict[str, Any]:
     """Parse ``pyproject.toml`` file and return relevant parts for Interrogate.
 
     :param str path_config: Path to ``pyproject.toml`` file.
@@ -134,8 +135,7 @@ def parse_pyproject_toml(path_config: str) -> dict[str, Any]:
     :raise OSError: an I/O-related error when opening ``pyproject.toml``.
     :raise tomllib.TOMLDecodeError: unable to load ``pyproject.toml``.
     """
-    with open(path_config, "rb") as f:
-        pyproject_toml = tomllib.load(f)
+    pyproject_toml = tomllib.loads(Path(path_config).read_text())
     config = pyproject_toml.get("tool", {}).get("interrogate", {})
     return {
         k.replace("--", "").replace("-", "_"): v for k, v in config.items()
@@ -221,7 +221,7 @@ def read_config_file(
     if not value:
         paths = ctx.params.get("paths")
         if not paths:
-            paths = (os.path.abspath(os.getcwd()),)
+            paths = (Path.cwd(),)
         value = find_project_config(paths)
         if value is None:
             return None

--- a/src/interrogate/config.py
+++ b/src/interrogate/config.py
@@ -23,7 +23,7 @@ if TYPE_CHECKING:
 try:
     import tomllib
 except ImportError:
-    import tomli as tomllib  # type: ignore
+    import tomli as tomllib
 
 
 # TODO: idea: break out InterrogateConfig into two classes: one for

--- a/src/interrogate/coverage.py
+++ b/src/interrogate/coverage.py
@@ -7,6 +7,7 @@ import ast
 import decimal
 import fnmatch
 import os
+from pathlib import Path
 import sys
 
 from typing import Final, Iterator
@@ -119,7 +120,7 @@ class InterrogateCoverage:
 
     def __init__(
         self,
-        paths: list[str],
+        paths: list[Path],
         conf: config.InterrogateConfig | None = None,
         excluded: tuple[str] | None = None,
         extensions: tuple[str] | None = None,

--- a/src/interrogate/coverage.py
+++ b/src/interrogate/coverage.py
@@ -19,6 +19,7 @@ from interrogate import config, utils, visit
 
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable
     from os import PathLike
 
 
@@ -123,7 +124,7 @@ class InterrogateCoverage:
 
     def __init__(
         self,
-        paths: list[PathLike[str] | str],
+        paths: Iterable[PathLike[str] | str],
         conf: config.InterrogateConfig | None = None,
         excluded: tuple[str] | None = None,
         extensions: tuple[str] | None = None,
@@ -141,7 +142,7 @@ class InterrogateCoverage:
     def _add_common_exclude(self) -> None:
         """Ignore common directories by default"""
         for path in self.paths:
-            self.excluded = self.excluded + tuple(  # type: ignore
+            self.excluded = self.excluded + tuple(
                 str(path / i) for i in self.COMMON_EXCLUDE
             )
 

--- a/src/interrogate/coverage.py
+++ b/src/interrogate/coverage.py
@@ -6,9 +6,9 @@ from __future__ import annotations
 import ast
 import decimal
 import os
-from pathlib import Path
-
 import sys
+
+from pathlib import Path
 from typing import TYPE_CHECKING, Final, Iterator
 
 import attr
@@ -16,6 +16,7 @@ import click
 import tabulate
 
 from interrogate import config, utils, visit
+
 
 if TYPE_CHECKING:
     from os import PathLike
@@ -252,7 +253,9 @@ class InterrogateCoverage:
         source_tree = filename.read_text(encoding="utf-8")
 
         parsed_tree = ast.parse(source_tree)
-        visitor = visit.CoverageVisitor(filename=str(filename), config=self.config)
+        visitor = visit.CoverageVisitor(
+            filename=str(filename), config=self.config
+        )
         visitor.visit(parsed_tree)
 
         filtered_nodes = self._filter_nodes(visitor.nodes)
@@ -474,7 +477,7 @@ class InterrogateCoverage:
         #     pth = Path.home() / "dev/download/interrogate/log.txt"
         #     with pth.open("a") as f:
         #         f.write(f"{cnt} {obj!r}\n")
-        
+
         # log(all_filenames_map)  # 1
         # log(all_filenames_map_paths)  # 2
         # log(all_dirs)  # 3

--- a/src/interrogate/utils.py
+++ b/src/interrogate/utils.py
@@ -6,11 +6,11 @@ from __future__ import annotations
 import contextlib
 import functools
 import os
-import pathlib
 import re
 import shutil
 import sys
 
+from pathlib import Path
 from typing import IO, Any, Final, Iterator, Sequence
 
 import colorama
@@ -57,7 +57,7 @@ def smart_open(
     :type fmode: ``str`` or ``None``
     """
     if filename and filename != "-":
-        fh = open(filename, fmode)
+        fh = Path(filename).open(fmode)
     else:
         fh = sys.stdout
 
@@ -68,7 +68,7 @@ def smart_open(
             fh.close()
 
 
-def get_common_base(files: Sequence[str | pathlib.Path]) -> str:
+def get_common_base(files: Sequence[str | Path]) -> str:
     """Find the common parent base path for a list of files.
 
     For example, ``["/usr/src/app", "/usr/src/tests", "/usr/src/app2"]``
@@ -79,7 +79,7 @@ def get_common_base(files: Sequence[str | pathlib.Path]) -> str:
     :return: Common parent path.
     :rtype: str
     """
-    commonbase = pathlib.Path(os.path.commonprefix(files))
+    commonbase = Path(os.path.commonprefix(files))
     # commonprefix may return an invalid path, e.g. for "/usr/foobar"
     # and "/usr/foobaz", it will return "/usr/fooba", so we'll need to
     # find its parent directory if that's the case.

--- a/src/interrogate/visit.py
+++ b/src/interrogate/visit.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 import ast
-import os
 
+from pathlib import Path
 from typing import Union
 
 import attr
@@ -71,7 +71,7 @@ class CoverageVisitor(ast.NodeVisitor):
     def _visit_helper(self, node: DocumentableNode) -> None:
         """Recursively visit AST node for docstrings."""
         if not hasattr(node, "name"):
-            node_name = os.path.basename(self.filename)
+            node_name = Path(self.filename).name
         else:
             node_name = node.name
 

--- a/tests/functional/test_cli.py
+++ b/tests/functional/test_cli.py
@@ -2,6 +2,7 @@
 """Functional tests for the CLI and implicitly interrogate/visit.py."""
 
 import sys
+
 from pathlib import Path
 
 import pytest

--- a/tests/functional/test_coverage.py
+++ b/tests/functional/test_coverage.py
@@ -2,8 +2,9 @@
 """Functional tests for interrogate/coverage.py."""
 
 import os
-from pathlib import Path
 import sys
+
+from pathlib import Path
 
 import pytest
 

--- a/tests/functional/test_coverage.py
+++ b/tests/functional/test_coverage.py
@@ -1,7 +1,6 @@
 # Copyright 2020-2024 Lynn Root
 """Functional tests for interrogate/coverage.py."""
 
-import os
 import sys
 
 from pathlib import Path

--- a/tests/functional/test_coverage.py
+++ b/tests/functional/test_coverage.py
@@ -2,6 +2,7 @@
 """Functional tests for interrogate/coverage.py."""
 
 import os
+from pathlib import Path
 import sys
 
 import pytest
@@ -9,9 +10,9 @@ import pytest
 from interrogate import config, coverage
 
 
-HERE = os.path.abspath(os.path.join(os.path.abspath(__file__), os.path.pardir))
-SAMPLE_DIR = os.path.join(HERE, "sample")
-FIXTURES = os.path.join(HERE, "fixtures")
+HERE = Path(__file__).parent
+SAMPLE_DIR = HERE / "sample"
+FIXTURES = HERE / "fixtures"
 IS_WINDOWS = sys.platform in ("cygwin", "win32")
 
 
@@ -26,14 +27,14 @@ def patch_term_width(monkeypatch):
     (
         (
             [
-                os.path.join(SAMPLE_DIR, "empty.py"),
+                SAMPLE_DIR / "empty.py",
             ],
             {},
             (1, 0, 1, "0.0"),
         ),
         (
             [
-                os.path.join(SAMPLE_DIR, "empty.py"),
+                SAMPLE_DIR / "empty.py",
             ],
             {"ignore_module": True},
             (0, 0, 0, "100.0"),
@@ -45,31 +46,31 @@ def patch_term_width(monkeypatch):
             {},
             (74, 38, 36, "51.4"),
         ),
-        ([os.path.join(SAMPLE_DIR, "partial.py")], {}, (29, 10, 19, "34.5")),
+        ([SAMPLE_DIR / "partial.py"], {}, (29, 10, 19, "34.5")),
         (
             [
-                os.path.join(SAMPLE_DIR, "full.py"),
+                SAMPLE_DIR / "full.py",
             ],
             {"ignore_nested_functions": True},
             (28, 26, 2, "92.9"),
         ),
         (
             [
-                os.path.join(SAMPLE_DIR, "partial.py"),
+                SAMPLE_DIR / "partial.py",
             ],
             {"ignore_nested_functions": True},
             (27, 9, 18, "33.3"),
         ),
         (
             [
-                os.path.join(SAMPLE_DIR, "full.py"),
+                SAMPLE_DIR / "full.py",
             ],
             {"ignore_overloaded_functions": True},
             (25, 23, 2, "92.0"),
         ),
         (
             [
-                os.path.join(SAMPLE_DIR, "partial.py"),
+                SAMPLE_DIR / "partial.py",
             ],
             {"ignore_overloaded_functions": True},
             (25, 10, 15, "40.0"),
@@ -91,7 +92,7 @@ def test_coverage_simple(paths, conf, exp_results, mocker):
 
 def test_coverage_errors(capsys):
     """Exit when no Python files are found."""
-    path = os.path.join(SAMPLE_DIR, "ignoreme.txt")
+    path = SAMPLE_DIR / "ignoreme.txt"
     interrogate_coverage = coverage.InterrogateCoverage(paths=[path])
 
     with pytest.raises(SystemExit, match="1"):
@@ -132,11 +133,10 @@ def test_print_results(level, exp_fixture_file, capsys, monkeypatch):
     )
 
     captured = capsys.readouterr()
-    expected_fixture = os.path.join(FIXTURES, exp_fixture_file)
+    expected_fixture = FIXTURES / exp_fixture_file
     if IS_WINDOWS:
-        expected_fixture = os.path.join(FIXTURES, "windows", exp_fixture_file)
-    with open(expected_fixture) as f:
-        expected_out = f.read()
+        expected_fixture = FIXTURES / "windows" / exp_fixture_file
+    expected_out = expected_fixture.read_text()
 
     assert expected_out in captured.out
     assert "omitted due to complete coverage" not in captured.out
@@ -166,11 +166,10 @@ def test_print_results_omit_covered(
     )
 
     captured = capsys.readouterr()
-    expected_fixture = os.path.join(FIXTURES, exp_fixture_file)
+    expected_fixture = FIXTURES / exp_fixture_file
     if IS_WINDOWS:
-        expected_fixture = os.path.join(FIXTURES, "windows", exp_fixture_file)
-    with open(expected_fixture) as f:
-        expected_out = f.read()
+        expected_fixture = FIXTURES / "windows" / exp_fixture_file
+    expected_out = expected_fixture.read_text()
 
     assert expected_out in captured.out
 
@@ -180,7 +179,7 @@ def test_print_results_omit_none(level, capsys, monkeypatch):
     """Output of test results by verbosity, no fully covered files."""
     interrogate_config = config.InterrogateConfig(omit_covered_files=True)
     interrogate_coverage = coverage.InterrogateCoverage(
-        paths=[os.path.join(SAMPLE_DIR, "child_sample")],
+        paths=[SAMPLE_DIR / "child_sample"],
         conf=interrogate_config,
     )
     results = interrogate_coverage.get_coverage()
@@ -198,7 +197,7 @@ def test_print_results_omit_all_summary(capsys, monkeypatch):
         omit_covered_files=True, docstring_style="google"
     )
     interrogate_coverage = coverage.InterrogateCoverage(
-        paths=[os.path.join(SAMPLE_DIR, "full.py")], conf=interrogate_config
+        paths=[SAMPLE_DIR / "full.py"], conf=interrogate_config
     )
     results = interrogate_coverage.get_coverage()
     interrogate_coverage.print_results(
@@ -207,11 +206,10 @@ def test_print_results_omit_all_summary(capsys, monkeypatch):
 
     captured = capsys.readouterr()
     exp_fixture_file = "expected_summary_skip_covered_all.txt"
-    expected_fixture = os.path.join(FIXTURES, exp_fixture_file)
+    expected_fixture = FIXTURES / exp_fixture_file
     if IS_WINDOWS:
-        expected_fixture = os.path.join(FIXTURES, "windows", exp_fixture_file)
-    with open(expected_fixture) as f:
-        expected_out = f.read()
+        expected_fixture = FIXTURES / "windows" / exp_fixture_file
+    expected_out = expected_fixture.read_text()
 
     assert expected_out in captured.out
 
@@ -222,7 +220,7 @@ def test_print_results_omit_all_detailed(capsys, monkeypatch):
         omit_covered_files=True, docstring_style="google"
     )
     interrogate_coverage = coverage.InterrogateCoverage(
-        paths=[os.path.join(SAMPLE_DIR, "full.py")], conf=interrogate_config
+        paths=[SAMPLE_DIR / "full.py"], conf=interrogate_config
     )
     results = interrogate_coverage.get_coverage()
     interrogate_coverage.print_results(
@@ -260,18 +258,17 @@ def test_print_results_ignore_module(
     )
 
     captured = capsys.readouterr()
-    expected_fixture = os.path.join(FIXTURES, exp_fixture_file)
+    expected_fixture = FIXTURES / exp_fixture_file
     if IS_WINDOWS:
-        expected_fixture = os.path.join(FIXTURES, "windows", exp_fixture_file)
-    with open(expected_fixture) as f:
-        expected_out = f.read()
+        expected_fixture = FIXTURES / "windows" / exp_fixture_file
+    expected_out = expected_fixture.read_text()
 
     assert expected_out in captured.out
 
 
 def test_print_results_single_file(capsys, monkeypatch):
     """Results for a single file should still list the filename."""
-    single_file = os.path.join(SAMPLE_DIR, "full.py")
+    single_file = SAMPLE_DIR / "full.py"
     conf = {"docstring_style": "google"}
     conf = config.InterrogateConfig(**conf)
     interrogate_coverage = coverage.InterrogateCoverage(
@@ -283,17 +280,14 @@ def test_print_results_single_file(capsys, monkeypatch):
     )
 
     captured = capsys.readouterr()
-    expected_fixture = os.path.join(
-        FIXTURES, "expected_detailed_single_file.txt"
-    )
+    expected_fixture = FIXTURES / "expected_detailed_single_file.txt"
 
     if IS_WINDOWS:
-        expected_fixture = os.path.join(
-            FIXTURES, "windows", "expected_detailed_single_file.txt"
+        expected_fixture = (
+            FIXTURES / "windows" / "expected_detailed_single_file.txt"
         )
 
-    with open(expected_fixture) as f:
-        expected_out = f.read()
+    expected_out = expected_fixture.read_text()
 
     assert expected_out in captured.out
     # I don't want to deal with path mocking out just to get tests to run

--- a/tests/unit/test_badge_gen.py
+++ b/tests/unit/test_badge_gen.py
@@ -1,8 +1,9 @@
 # Copyright 2020-2024 Lynn Root
 """Unit tests for interrogate/badge_gen.py module"""
 
-from pathlib import Path
 import sys
+
+from pathlib import Path
 
 import pytest
 
@@ -20,7 +21,11 @@ IS_WINDOWS = sys.platform in ("cygwin", "win32")
     (
         (None, Path("fixtures/my_badge.svg"), Path("fixtures/my_badge.svg")),
         ("svg", Path("fixtures/my_badge.svg"), Path("fixtures/my_badge.svg")),
-        ("png", Path("fixtures/my_badge.png"), Path("fixtures/my_badge.tmp.svg")),
+        (
+            "png",
+            Path("fixtures/my_badge.png"),
+            Path("fixtures/my_badge.tmp.svg"),
+        ),
     ),
 )
 def test_save_badge(

--- a/tests/unit/test_badge_gen.py
+++ b/tests/unit/test_badge_gen.py
@@ -74,9 +74,7 @@ def test_get_badge():
     actual = badge_gen.get_badge(99.9, "#4c1")
     actual = actual.replace("\n", "").replace("\r", "")
     expected_fixture = FIXTURES / "default-style" / "99.svg"
-    with open(expected_fixture) as f:
-        expected = f.read()
-        expected = expected.replace("\n", "").replace("\r", "")
+    expected = expected_fixture.read_text().replace("\n", "").replace("\r", "")
 
     assert expected == actual
 
@@ -182,18 +180,21 @@ def test_create(
         str(output), mock_result, out_format, output_style=style
     )
 
-    flag = "rb" if out_format == "png" else "r"
-    with open(actual, flag) as f:
-        actual_contents = f.read()
-        if out_format is None:
-            actual_contents = actual_contents.replace("\n", "")
+    actual_contents = (
+        actual.read_bytes() if out_format == "png" else actual.read_text()
+    )
+    if out_format is None:
+        actual_contents = actual_contents.replace("\n", "")
 
     if style is None:
         style = "default-style"
     expected_fixture = FIXTURES / style / expected_fixture
-    with open(expected_fixture, flag) as f:
-        expected_contents = f.read()
-        if out_format is None:
-            expected_contents = expected_contents.replace("\n", "")
+    expected_contents = (
+        expected_fixture.read_bytes()
+        if out_format == "png"
+        else expected_fixture.read_text()
+    )
+    if out_format is None:
+        expected_contents = expected_contents.replace("\n", "")
 
     assert expected_contents == actual_contents

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -2,6 +2,7 @@
 """Unit tests for interrogate/config.py module"""
 
 import configparser
+
 from pathlib import Path
 
 import click

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -2,7 +2,7 @@
 """Unit tests for interrogate/config.py module"""
 
 import configparser
-import pathlib
+from pathlib import Path
 
 import click
 import pytest
@@ -34,10 +34,10 @@ from interrogate import config
 def test_find_project_root(srcs, patch_func, expected, monkeypatch):
     """Return expected directory of project root."""
     with monkeypatch.context() as mp:
-        expected = pathlib.Path(expected)
+        expected = Path(expected)
         if patch_func:
-            mp.setattr(config.pathlib.Path, patch_func, lambda x: True)
-        mp.setattr(config.pathlib.Path, "resolve", lambda x: x)
+            mp.setattr(config.Path, patch_func, lambda x: True)
+        mp.setattr(config.Path, "resolve", lambda x: x)
 
         actual = config.find_project_root(srcs)
 
@@ -47,15 +47,15 @@ def test_find_project_root(srcs, patch_func, expected, monkeypatch):
 @pytest.mark.parametrize(
     "is_file,expected",
     (
-        (True, str(pathlib.Path("/usr/src/pyproject.toml"))),
+        (True, str(Path("/usr/src/pyproject.toml"))),
         (False, None),
     ),
 )
 def test_find_project_config(is_file, expected, mocker, monkeypatch):
     """Return absolute path if pyproject.toml or setup.cfg is detected."""
     with monkeypatch.context() as mp:
-        mp.setattr(config.pathlib.Path, "is_file", lambda x: is_file)
-        mp.setattr(config.pathlib.Path, "resolve", lambda x: x)
+        mp.setattr(config.Path, "is_file", lambda x: is_file)
+        mp.setattr(config.Path, "resolve", lambda x: x)
 
         actual = config.find_project_config(("/usr/src/app",))
         assert expected == actual

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -37,13 +37,13 @@ def test_parse_regex(value, exp):
 def test_smart_open(filename, mocker):
     """Handles both opening a file and stdout in the same manner."""
     m_open = mocker.mock_open()
-    mock_open = mocker.patch("interrogate.utils.open", m_open)
+    mock_open = mocker.patch("interrogate.utils.Path.open", m_open)
 
     with utils.smart_open(filename, fmode="r") as act_ret:
         pass
 
     if filename and filename != "-":
-        mock_open.assert_called_once_with(filename, "r")
+        mock_open.assert_called_once_with("r")
         assert act_ret.closed
     else:
         mock_open.assert_not_called()
@@ -67,7 +67,7 @@ def test_smart_open(filename, mocker):
 def test_get_common_base(files, side_effect, expected, mocker, monkeypatch):
     """Return common base of a set of files/directories, if any."""
     mock_exists = mocker.Mock(side_effect=side_effect)
-    monkeypatch.setattr(utils.pathlib.Path, "exists", mock_exists)
+    monkeypatch.setattr(utils.Path, "exists", mock_exists)
     actual = utils.get_common_base(files)
     assert expected == actual
 
@@ -100,7 +100,7 @@ def test_get_common_base_windows(
 ):
     """Return common base of a set of files/directories, if any."""
     mock_exists = mocker.Mock(side_effect=side_effect)
-    monkeypatch.setattr(utils.pathlib.Path, "exists", mock_exists)
+    monkeypatch.setattr(utils.Path, "exists", mock_exists)
     actual = utils.get_common_base(files)
     assert expected == actual
 


### PR DESCRIPTION
# Hey, I just made a Pull Request!

## Description
Changes all occurrences of `os.path` to use `pathlib` instead.

## Motivation and Context
Closes #179

## Have you tested this? If so, how?
Updated unit tests :)

## Checklist for PR author(s)
<!-- If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing left to do. -->
- [x] Changes are covered by unit tests (no major decrease in code coverage %).
- [x] All tests pass.
- [x] Docstring coverage is **100%** via `tox -e docs` or `interrogate -c pyproject.toml` (I mean, we _should_ set a good example :smile:).
- [ ] Updates to documentation:
    - [x] Document any relevant additions/changes in `README.rst`.
    - [x] Manually update **both** the `README.rst` _and_ `docs/index.rst` for any new/changed CLI flags.
    - [ ] Any changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/markup/para.html#directive-versionadded).  Find the appropriate next version in the project's [``__init__.py``](https://github.com/econchick/interrogate/blob/master/src/interrogate/__init__.py) file.

## Release note
<!--  If your change is non-trivial (e.g. more than a fixed typo in docs, or updated tests), please write a suggested release note for us to include in `docs/changelog.rst` (we may edit it a bit).

1. Enter your release note in the below block. If the PR requires additional action from users switching to the new release, start the release note with the string "action required: ". Please write it in the imperative.
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
