### PR TITLE
Support (and require) tabulate version 0.10.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,7 @@ INSTALL_REQUIRES = [
     "click>=7.1",
     "colorama",
     "py",
-    "tabulate",
+    "tabulate>=0.10.0",
     "tomli; python_version < '3.11'",
 ]
 EXTRAS_REQUIRE = {

--- a/src/interrogate/coverage.py
+++ b/src/interrogate/coverage.py
@@ -18,9 +18,6 @@ import tabulate
 from interrogate import config, utils, visit
 
 
-tabulate.PRESERVE_WHITESPACE = True
-
-
 @attr.s
 class BaseInterrogateResult:
     """Base results class.
@@ -382,6 +379,7 @@ class InterrogateCoverage:
                 table_type="detailed"
             ),
             colalign=["left", "right"],
+            preserve_whitespace=True,
         )
         self.output_formatter.tw.sep(
             "-",
@@ -450,6 +448,7 @@ class InterrogateCoverage:
                 table_type="summary"
             ),
             colalign=("left", "right", "right", "right", "right"),
+            preserve_whitespace=True,
         )
         self.output_formatter.tw.line(to_print)
 
@@ -519,6 +518,7 @@ class InterrogateCoverage:
                 table_type="summary"
             ),
             colalign=("center",),
+            preserve_whitespace=True,
         )
         self.output_formatter.tw.line(to_print)
 


### PR DESCRIPTION
# Hey, I just made a Pull Request!

## Description
<!--- Describe your changes -->
The `tabulate.PRESERVE_WHITESPACE` global was replaced with a new `preserve_whitespace` keyword argument for `tabulate()`.

Since preserving backward compatibility with previous `tabulate` versions would be tedious, requiring various conditionals and parsing `tabulate.__version__`, support *only* `tabulate>=0.10.0`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

```
$ uv venv
Using CPython 3.14.3 interpreter at: /usr/bin/python3
Creating virtual environment at: .venv
Activate with: source .venv/bin/activate
$ . .venv/bin/activate
(interrogate) $ uv pip install -e .
(interrogate) $ uv pip install pytest pytest-mock
(interrogate) $ pytest
[…]
================================================================================== short test summary info ==================================================================================
SKIPPED [1] tests/unit/test_badge_gen.py:49: windows-only tests
SKIPPED [5] tests/unit/test_utils.py:75: windows-only tests
SKIPPED [7] tests/unit/test_utils.py:278: windows-only tests
FAILED tests/functional/test_coverage.py::test_print_results[2-expected_detailed.txt] - AssertionError: assert '------------------------------ Detailed Coverage -------------------------------\n| Name                             ...                     |    MISSED |\n|---...
FAILED tests/functional/test_coverage.py::test_print_results_omit_covered[2-expected_detailed_skip_covered.txt] - AssertionError: assert '------------------------------ Detailed Coverage -------------------------------\n| Name                             ...                     |    MISSED |\n|---...
FAILED tests/functional/test_coverage.py::test_print_results_ignore_module[False-2-expected_detailed.txt] - AssertionError: assert '------------------------------ Detailed Coverage -------------------------------\n| Name                             ...                     |    MISSED |\n|---...
FAILED tests/functional/test_coverage.py::test_print_results_ignore_module[True-2-expected_detailed_no_module.txt] - AssertionError: assert '------------------------------ Detailed Coverage -------------------------------\n| Name                             ...                     |    MISSED |\n|---...
FAILED tests/functional/test_coverage.py::test_print_results_single_file - AssertionError: assert '------------------------------ Detailed Coverage -------------------------------\n| Name                             ...0 |           29 |        100.0% |\n----...
=================================================================== 5 failed, 223 passed, 13 skipped, 1 warning in 0.39s ====================================================================
```

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." and -->
<!--- "I ran `interrogate` with these changes over some code and it works for me." -->

Repeat the above `pytest` invocation and observe:

```
================================================================================== short test summary info ==================================================================================
SKIPPED [1] tests/unit/test_badge_gen.py:49: windows-only tests
SKIPPED [5] tests/unit/test_utils.py:75: windows-only tests
SKIPPED [7] tests/unit/test_utils.py:278: windows-only tests
======================================================================== 228 passed, 13 skipped, 1 warning in 0.34s =========================================================================
```

## Checklist for PR author(s)
<!-- If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing left to do. -->
- [x] Changes are covered by unit tests (no major decrease in code coverage %).
- [x] All tests pass.
- [x] Docstring coverage is **100%** via `tox -e docs` or `interrogate -c pyproject.toml` (I mean, we _should_ set a good example :smile:).
- [ ] Updates to documentation:
    - [ ] Document any relevant additions/changes in `README.rst`.
    - [ ] Manually update **both** the `README.rst` _and_ `docs/index.rst` for any new/changed CLI flags.
    - [ ] Any changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/markup/para.html#directive-versionadded).  Find the appropriate next version in the project's [``__init__.py``](https://github.com/econchick/interrogate/blob/master/src/interrogate/__init__.py) file.

## Release note
<!--  If your change is non-trivial (e.g. more than a fixed typo in docs, or updated tests), please write a suggested release note for us to include in `docs/changelog.rst` (we may edit it a bit).

1. Enter your release note in the below block. If the PR requires additional action from users switching to the new release, start the release note with the string "action required: ". Please write it in the imperative.
2. If no release note is required, just write "NONE".
-->
```release-note
Added
^^^^^

* Support for `tabulate` 0.10.0 and later

Removed
^^^^^^^

* Support for `tabulate` versions older than 0.10.0
```

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->