### PR TITLE
Fix copy-paste error in -w/--whitelist-regex docs

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -100,7 +100,7 @@ Command Line Options
 
 .. option:: -w, --whitelist-regex STR
 
-    Regex identifying class, method, and function names to include. Multiple ``-r/--ignore-regex`` invocations supported.
+    Regex identifying class, method, and function names to include. Multiple ``-w/--whitelist-regex`` invocations supported.
 
 .. option:: --style [sphinx|google]
 


### PR DESCRIPTION
## What

Fix a copy-paste error in `docs/index.rst` where the `-w/--whitelist-regex` option description incorrectly referenced `-r/--ignore-regex` in its "Multiple invocations supported" note.

**Before:**
```
Regex identifying class, method, and function names to include. Multiple ``-r/--ignore-regex`` invocations supported.
```

**After:**
```
Regex identifying class, method, and function names to include. Multiple ``-w/--whitelist-regex`` invocations supported.
```

## Why

The `-w/--whitelist-regex` entry was clearly copied from the `-r/--ignore-regex` entry just above it and the flag reference was never updated. This is confirmed by the CLI source in `src/interrogate/cli.py` (line 203) and `README.rst`, both of which correctly show `-w/--whitelist-regex` for this option.

## How verified

Cross-referenced against `src/interrogate/cli.py` and `README.rst`.